### PR TITLE
Docs: 루트 README.md 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# 🏰 ZIPSA (집사)
+> AI 기반 고양이 품종 매칭 및 케어 상담 서비스
+
+![Python](https://img.shields.io/badge/Python-3.11+-3776AB?style=flat-square&logo=python)
+![LangGraph](https://img.shields.io/badge/LangGraph-1.0-FF9900?style=flat-square)
+![MongoDB Atlas](https://img.shields.io/badge/MongoDB%20Atlas-Vector%20Search-47A248?style=flat-square&logo=mongodb)
+![OpenAI](https://img.shields.io/badge/OpenAI-GPT--4o%20%7C%20GPT--4.1--nano-412991?style=flat-square&logo=openai)
+
+> 🚧 현재 개발 진행 중입니다.


### PR DESCRIPTION
## 개요
루트 README.md가 없어 GitHub 레포 첫 화면이 비어있어 최소한의 README를 추가합니다.

## 변경 사항
- 루트 `README.md` 추가 (프로젝트명, 한 줄 설명, 기술 스택 배지)
- 상세 내용은 개발 완료 후 작성 예정

## 관련 이슈
없음