### PR TITLE
fix: HybridRetriever 생성자 version 파라미터 불일치 제거

### DIFF
--- a/src/agents/care_team.py
+++ b/src/agents/care_team.py
@@ -66,7 +66,7 @@ async def care_team_node(state: AgentState) -> Command:
     persona = prompt_manager.get_prompt(config["persona_key"], field="persona")
 
     # 3. 전문가 태그 기반 RAG 검색
-    retriever = HybridRetriever(version="v3", collection_name="care_guides")
+    retriever = HybridRetriever(collection_name="care_guides")
     results = await retriever.search(
         last_msg, specialist=config["specialist_tag"], limit=3
     )

--- a/src/agents/liaison.py
+++ b/src/agents/liaison.py
@@ -60,7 +60,7 @@ async def liaison_node(state: AgentState) -> Command:
         )
 
     # 2. 리에종 전문가 태그 기반 RAG 검색
-    retriever = HybridRetriever(version="v3", collection_name="care_guides")
+    retriever = HybridRetriever(collection_name="care_guides")
     raw_results = await retriever.search(
         query, specialist="Liaison", limit=3
     )

--- a/src/agents/matchmaker.py
+++ b/src/agents/matchmaker.py
@@ -56,7 +56,7 @@ async def matchmaker_node(state: AgentState) -> Command:
     print(f"🕵️ [MATCHMAKER] Intent: {intent.category}, Query: {search_query}")
 
     # 3. 10건 후보 검색
-    retriever = HybridRetriever(version="v3", collection_name="care_guides")
+    retriever = HybridRetriever(collection_name="care_guides")
     raw_results = await retriever.search(
         search_query, 
         specialist="Matchmaker", # 필터링용 메타데이터 태그


### PR DESCRIPTION
## 개요
`HybridRetriever.__init__`에서 `version` 파라미터가 제거됐지만, 이를 호출하는 agent 파일들이 여전히 `version="v3"`를 전달하고 있어 에러 발생

## 변경 사항
- `src/agents/care_team.py`: `HybridRetriever(version="v3", ...)` → `HybridRetriever(...)`
- `src/agents/liaison.py`: 동일
- `src/agents/matchmaker.py`: 동일

## 관련 이슈
- Closes #

## 기타

---

- [x] 타입 힌트 작성
- [x] 4-space 들여쓰기 적용
- [ ] 관련 이슈 연결