### PR TITLE
fix: uvloop 버전 및 Windows 제외 플랫폼 마커 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ motor
 streamlit>=1.41.0
 altair>=5.0.0
 httpx
-uvloop
+uvloop==0.22.1; sys_platform != 'win32'
 jinja2
 pydantic
 langsmith


### PR DESCRIPTION
## 개요
Windows 환경에서 uvloop 설치 시 오류 발생. 플랫폼 조건부 설치 마커 추가.

## 변경 사항
- `requirements.txt`: `uvloop` → `uvloop==0.22.1; sys_platform != 'win32'`

## 관련 이슈
- Closes #

## 기타

---

- [x] 타입 힌트 작성
- [x] 4-space 들여쓰기 적용
- [ ] 관련 이슈 연결