### PR TITLE
feat: 품종 필터링 정책 정의 및 Hard filter + fallback 모듈 구현

### DIFF
--- a/docs/06_feature/breed_filtering_policy.md
+++ b/docs/06_feature/breed_filtering_policy.md
@@ -1,0 +1,141 @@
+# 품종 필터링 정책 (Breed Filtering Policy)
+
+## 1. 개요
+
+사용자의 자연어 표현에서 품종 선호 조건을 추출하여 MongoDB 필터로 적용합니다.
+조건을 만족하는 품종이 부족할 경우 단계적 fallback을 적용합니다.
+
+### 설계 방식: Hard Filter + Fallback
+
+```
+자연어 → 조건 추출 (LLM) → MongoDB Hard Filter → 후보 검색 → LLM 최종 선별
+                                     ↓ 결과 < 3종
+                              Fallback (단계적 완화)
+```
+
+> Soft hint 방식(프롬프트 힌트 주입)은 LLM이 조건을 무시할 수 있어 채택하지 않습니다.
+
+---
+
+---
+
+## 2. 실제 데이터 분포 (67종 기준)
+
+필터 설계의 근거가 되는 실제 stats 분포입니다.
+
+### 2.1 단일 조건별 매칭 수
+
+| 조건 | 매칭 수 | 비율 | 비고 |
+|---|---|---|---|
+| `shedding_level <= 2` | 18종 | 27% | 사용 |
+| `shedding_level <= 3` | 60종 | 90% | fallback |
+| `energy_level <= 3` | 26종 | 39% | 사용 ("얌전한") |
+| `energy_level >= 4` | 41종 | 61% | 사용 ("활발한") |
+| `energy_level <= 2` | 4종 | 6% | 너무 strict → 미사용 |
+| `vocalisation <= 2` | 27종 | 40% | 사용 |
+| `social_needs <= 3` | — | — | 실제 min=3이므로 최소 기준 |
+| `social_needs <= 2` | 0종 | 0% | **불가** (실제 min=3) |
+| `child_friendly >= 4` | 57종 | 85% | 분화 없음 → 미사용 |
+| `affection_level >= 4` | 65종 | 97% | 분화 없음 → 미사용 |
+| `hypoallergenic == 1` | 15종 | 22% | 사용 |
+| `grooming <= 2` | 48종 | 72% | 사용 |
+
+### 2.2 복합 조건 (AND) 매칭 수
+
+| 조건 조합 | 매칭 수 | 비고 |
+|---|---|---|
+| `shedding_level <= 2` + `energy_level <= 2` | 0종 | fallback 필요 |
+| `shedding_level <= 2` + `hypoallergenic == 1` | 6종 | 정상 |
+| `child_friendly >= 4` + `energy_level <= 3` | 20종 | 정상 |
+| `social_needs <= 2` + `grooming <= 2` | 0종 | social_needs 불가 |
+| `energy_level >= 4` + `affection_level >= 4` | 41종 | affection 분화 없음 |
+
+### 2.3 필터에서 제외하는 필드
+
+실제 데이터 분포상 거의 모든 품종이 높은 값을 가져 필터 의미가 없는 필드:
+
+| 필드 | 이유 |
+|---|---|
+| `affection_level` | 97%가 4-5 |
+| `child_friendly` | 85%가 >= 4 |
+| `adaptability` | 평균 4.8, 대부분 5 |
+| `dog_friendly` | 평균 4.6 |
+
+---
+
+## 3. Stats 필드 정의 (1-5 척도)
+
+| 필드 | 설명 | 낮음 (1-2) | 높음 (4-5) |
+|---|---|---|---|
+| `shedding_level` | 털 빠짐 정도 | 털 거의 안 빠짐 | 털 많이 빠짐 |
+| `energy_level` | 활동성 | 얌전함, 조용함 | 활발함, 에너지 넘침 |
+| `affection_level` | 애정도 | 독립적 | 애교 많음 |
+| `child_friendly` | 아이 친화성 | 아이 비추 | 아이 있는 집 적합 |
+| `social_needs` | 사회적 욕구 | 혼자 있어도 잘 지냄 | 혼자 두면 힘들어함 |
+| `vocalisation` | 울음소리 빈도 | 조용함 | 말이 많음 |
+| `grooming` | 그루밍 필요도 | 관리 쉬움 | 자주 빗질 필요 |
+| `intelligence` | 지능 | — | 훈련 가능, 영리함 |
+| `stranger_friendly` | 낯선 사람 친화성 | 낯을 많이 가림 | 사교적 |
+| `adaptability` | 적응력 | 환경 변화에 민감 | 새 환경 잘 적응 |
+| `health_issues` | 건강 문제 빈도 | 건강한 편 | 유전 질환 주의 |
+| `hypoallergenic` | 저알레르기 여부 | — | 0 또는 1 |
+| `lap` | 무릎냥이 여부 | — | 0 또는 1 |
+| `indoor` | 실내 적합도 | — | 0 또는 1 |
+
+---
+
+## 4. 자연어 → 조건 매핑 예시
+
+| 사용자 표현 | 추출 조건 |
+|---|---|
+| "털 안 빠지는" | `shedding_level <= 2` |
+| "털 많이 빠지는 건 싫어" | `shedding_level <= 2` |
+| "활발한", "에너지 넘치는" | `energy_level >= 4` |
+| "얌전한", "조용한", "아파트용" | `energy_level <= 2` |
+| "소리 안 내는" | `vocalisation <= 2` |
+| "아이 있는 집", "아이 친화적" | `child_friendly >= 4` |
+| "초보자", "처음 키우는" | `energy_level <= 3`, `grooming <= 3` |
+| "애교 많은", "사람 좋아하는" | `affection_level >= 4` |
+| "독립적인", "혼자 있어도 되는" | `social_needs <= 2` |
+| "알레르기" | `hypoallergenic == 1` |
+| "무릎냥이" | `lap == 1` |
+| "영리한", "훈련 가능한" | `intelligence >= 4` |
+| "그루밍 적게", "관리 쉬운" | `grooming <= 2` |
+
+---
+
+## 5. 적용 흐름
+
+```
+1. 사용자 발화 입력
+2. extract_breed_criteria(query) → BreedCriteriaHints 추출
+3. preferred_conditions가 있으면 LLM 선별 프롬프트에 [선호 조건 힌트] 섹션 추가
+4. LLM은 힌트를 참고하되 전체 적합성을 종합 판단하여 최종 3종 선별
+```
+
+### Fallback 단계
+
+| 단계 | 동작 | 프롬프트 메시지 |
+|---|---|---|
+| 1단계 | 전체 조건 적용, 결과 >= 3종 | — |
+| 2단계 | 수치 threshold ±1 완화 | "기준을 완화하여 검색했습니다" |
+| 3단계 | 바이너리 조건만 유지 (hypoallergenic, lap) | "수치 조건을 제거하고 필수 조건만 적용했습니다" |
+| 4단계 | 조건 없음 | "전체 품종에서 검색합니다" |
+
+### 선별 프롬프트 주입 예시
+
+```
+[적용된 검색 조건]
+shedding_level <= 3, energy_level <= 3
+※ 원하시는 조건(shedding_level <= 2, energy_level <= 2)을 모두 만족하는 품종이
+  부족해 기준을 완화하여 검색했습니다.
+위 조건이 반영된 후보 목록입니다. 사용자 환경과 종합하여 최적의 3종을 선별하세요.
+```
+
+---
+
+## 6. 관련 파일
+
+- `src/agents/filters/breed_criteria.py` — 조건 추출 모듈
+- `src/agents/matchmaker.py` — 힌트 주입 연동
+- `src/core/models/cat_card.py` — `CatCardStats` 필드 정의

--- a/src/agents/filters/breed_criteria.py
+++ b/src/agents/filters/breed_criteria.py
@@ -1,0 +1,185 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from langchain.chat_models import init_chat_model
+from langchain_core.messages import SystemMessage
+from src.core.config import LLMConfig, ZipsaConfig
+from src.utils.mongodb import MongoDBManager
+
+llm_router = init_chat_model(LLMConfig.ROUTER_MODEL, model_provider="openai", temperature=0)
+
+# 실제 데이터 기반 threshold 정의 (67종 분포 기준)
+# - affection_level, child_friendly, adaptability: 분화 없음 → 제외
+# - social_needs: 실제 min=3, "독립적인" 기준 <= 3
+# - energy_level: "얌전한" 기준 <= 3 (>= 4: 61%, <= 3: 39%)
+_SYSTEM_PROMPT = """사용자의 발화에서 고양이 품종 선호 조건을 추출하세요.
+
+아래 필드와 척도를 사용합니다:
+- shedding_level: 털 빠짐 (1-5, 높을수록 많이 빠짐)
+- energy_level: 활동성 (1-5, 높을수록 활발)
+- vocalisation: 울음소리 빈도 (1-5)
+- grooming: 그루밍 필요도 (1-5)
+- social_needs: 사회적 욕구 (3-5, 낮을수록 독립적)
+- hypoallergenic: 저알레르기 (0 또는 1)
+- lap: 무릎냥이 여부 (0 또는 1)
+
+표현 → 조건 매핑:
+- "털 안 빠지는", "털 적은" → shedding_level <= 2
+- "활발한", "에너지 넘치는" → energy_level >= 4
+- "얌전한", "조용한", "차분한" → energy_level <= 3
+- "소리 안 내는", "울음 적은" → vocalisation <= 2
+- "혼자 있어도 괜찮은", "독립적인" → social_needs <= 3
+- "알레르기" → hypoallergenic == 1
+- "무릎냥이" → lap == 1
+- "그루밍 적게", "관리 쉬운" → grooming <= 2
+
+조건 형식: "shedding_level <= 2", "energy_level >= 4", "hypoallergenic == 1"
+조건이 없으면 빈 리스트를 반환하세요."""
+
+_BINARY_FIELDS = {"hypoallergenic", "lap", "indoor"}
+_MIN_RESULT_COUNT = 3
+
+
+class _ExtractedConditions(BaseModel):
+    conditions: List[str] = Field(default_factory=list)
+
+
+class FilterResult(BaseModel):
+    """필터 적용 결과. matchmaker에서 RAG 검색 및 프롬프트 주입에 사용됩니다."""
+    original_conditions: List[str] = Field(default_factory=list)
+    applied_conditions: List[str] = Field(default_factory=list)
+    mongo_filter: dict = Field(default_factory=dict)
+    fallback_applied: bool = False
+    fallback_reason: str = ""
+
+
+def _parse_to_mongo(cond: str) -> tuple[Optional[str], object]:
+    """조건 문자열을 MongoDB 필터 (path, value)로 변환합니다."""
+    parts = cond.strip().split()
+    if len(parts) != 3:
+        return None, None
+    field, op, value_str = parts
+    try:
+        value = int(value_str)
+    except ValueError:
+        return None, None
+    path = f"stats.{field}"
+    if op == "<=":
+        return path, {"$lte": value}
+    elif op == ">=":
+        return path, {"$gte": value}
+    elif op == "==":
+        return path, value
+    return None, None
+
+
+def _conditions_to_mongo(conditions: List[str]) -> dict:
+    result = {}
+    for cond in conditions:
+        path, value = _parse_to_mongo(cond)
+        if path:
+            result[path] = value
+    return result
+
+
+def _relax(cond: str) -> str:
+    """수치 조건의 threshold를 ±1 완화합니다. 바이너리 조건은 그대로 반환합니다."""
+    parts = cond.strip().split()
+    if len(parts) != 3:
+        return cond
+    field, op, value_str = parts
+    if field in _BINARY_FIELDS:
+        return cond
+    try:
+        value = int(value_str)
+    except ValueError:
+        return cond
+    if op == "<=":
+        return f"{field} <= {value + 1}"
+    elif op == ">=":
+        return f"{field} >= {value - 1}"
+    return cond
+
+
+def _is_binary(cond: str) -> bool:
+    return cond.strip().split()[0] in _BINARY_FIELDS
+
+
+async def _count_breeds(collection, mongo_filter: dict) -> int:
+    base = {"categories": "Breeds"}
+    base.update(mongo_filter)
+    return await collection.count_documents(base)
+
+
+async def extract_breed_criteria(query: str) -> FilterResult:
+    """
+    사용자 발화에서 품종 필터 조건을 추출하고, 실제 데이터 기반 fallback을 적용합니다.
+
+    Fallback 순서:
+        1. 전체 조건 적용 → 결과 >= 3종이면 완료
+        2. 수치 조건 threshold ±1 완화
+        3. 바이너리 조건(hypoallergenic, lap)만 유지
+        4. 조건 없음 (전체 검색)
+    """
+    extractor = llm_router.with_structured_output(_ExtractedConditions)
+    extracted = await extractor.ainvoke(
+        [SystemMessage(content=_SYSTEM_PROMPT), SystemMessage(content=query)],
+        config={"tags": ["router_classification"]}
+    )
+    original = extracted.conditions
+
+    if not original:
+        return FilterResult()
+
+    policy = ZipsaConfig.get_policy("v3")
+    db = MongoDBManager.get_v3_db()
+    collection = db[policy.collection_name]
+
+    # 1단계: 전체 조건
+    mongo_filter = _conditions_to_mongo(original)
+    if await _count_breeds(collection, mongo_filter) >= _MIN_RESULT_COUNT:
+        return FilterResult(
+            original_conditions=original,
+            applied_conditions=original,
+            mongo_filter=mongo_filter,
+        )
+
+    # 2단계: 수치 조건 완화
+    relaxed = [_relax(c) for c in original]
+    mongo_filter_relaxed = _conditions_to_mongo(relaxed)
+    if await _count_breeds(collection, mongo_filter_relaxed) >= _MIN_RESULT_COUNT:
+        return FilterResult(
+            original_conditions=original,
+            applied_conditions=relaxed,
+            mongo_filter=mongo_filter_relaxed,
+            fallback_applied=True,
+            fallback_reason=(
+                f"원하시는 조건({', '.join(original)})을 모두 만족하는 품종이 부족해 "
+                f"기준을 완화({', '.join(relaxed)})하여 검색했습니다."
+            ),
+        )
+
+    # 3단계: 바이너리 조건만 유지
+    binary_only = [c for c in original if _is_binary(c)]
+    if binary_only:
+        mongo_filter_binary = _conditions_to_mongo(binary_only)
+        if await _count_breeds(collection, mongo_filter_binary) >= _MIN_RESULT_COUNT:
+            removed = [c for c in original if not _is_binary(c)]
+            return FilterResult(
+                original_conditions=original,
+                applied_conditions=binary_only,
+                mongo_filter=mongo_filter_binary,
+                fallback_applied=True,
+                fallback_reason=(
+                    f"수치 조건({', '.join(removed)})을 만족하는 품종이 부족해 "
+                    f"필수 조건({', '.join(binary_only)})만 적용했습니다."
+                ),
+            )
+
+    # 4단계: 조건 없음
+    return FilterResult(
+        original_conditions=original,
+        applied_conditions=[],
+        mongo_filter={},
+        fallback_applied=True,
+        fallback_reason="조건을 만족하는 품종이 충분하지 않아 전체 품종에서 검색합니다.",
+    )

--- a/src/agents/matchmaker.py
+++ b/src/agents/matchmaker.py
@@ -9,6 +9,7 @@ from src.core.prompts.prompt_manager import prompt_manager
 from src.retrieval.hybrid_search import HybridRetriever
 from src.core.models.user_profile import UserProfile
 from src.core.models.matchmaker import BreedSelection, SearchIntent
+from src.agents.filters.breed_criteria import extract_breed_criteria
 
 llm_router = init_chat_model(LLMConfig.ROUTER_MODEL, model_provider="openai", temperature=0)
 llm_basic = init_chat_model(LLMConfig.BASIC_MODEL, model_provider="openai", temperature=0)
@@ -43,24 +44,30 @@ async def matchmaker_node(state: AgentState) -> Command:
         SystemMessage(content=query)
     ], config={"tags": ["router_classification"]})
 
-    # 2. 검색 쿼리 구성
+    # 2. 검색 쿼리 구성 및 조건 추출
     if intent.category == "RECOMMEND":
-        # 추천: 프로필 적극 반영
+        # 추천: 프로필 적극 반영 + 선호 조건 추출 (Hard filter + fallback)
         search_query = f"{intent.keywords} (집사 환경: {context})"
         specialist_mode = "Matchmaker (Recommendation)"
+        filter_result = await extract_breed_criteria(query)
     else:
         # 단순 조회: 프로필 배제
         search_query = intent.keywords
         specialist_mode = "Matchmaker (Lookup)"
+        filter_result = None
         
     print(f"🕵️ [MATCHMAKER] Intent: {intent.category}, Query: {search_query}")
 
     # 3. 10건 후보 검색
+    search_filters = {"categories": "Breeds"}
+    if filter_result and filter_result.mongo_filter:
+        search_filters.update(filter_result.mongo_filter)
+
     retriever = HybridRetriever(collection_name="care_guides")
     raw_results = await retriever.search(
-        search_query, 
-        specialist="Matchmaker", # 필터링용 메타데이터 태그
-        filters={"categories": "Breeds"}, 
+        search_query,
+        specialist="Matchmaker",
+        filters=search_filters,
         limit=10
     )
 
@@ -87,6 +94,13 @@ async def matchmaker_node(state: AgentState) -> Command:
         selection_prompt += f"{i}. {r.get('name_ko')} ({r.get('name_en')}): {r.get('summary')}\n"
         selection_prompt += f"   - 특징: {', '.join(r.get('personality_traits', []))}\n"
         selection_prompt += f"   - 통계: {r.get('stats', {})}\n\n"
+
+    if filter_result and filter_result.applied_conditions:
+        conditions_str = ", ".join(filter_result.applied_conditions)
+        selection_prompt += f"\n[적용된 검색 조건]\n{conditions_str}\n"
+        if filter_result.fallback_applied:
+            selection_prompt += f"※ {filter_result.fallback_reason}\n"
+        selection_prompt += "위 조건이 반영된 후보 목록입니다. 사용자 환경과 종합하여 최적의 3종을 선별하세요.\n"
 
     selector = llm_router.with_structured_output(BreedSelection)
     selection = await selector.ainvoke(


### PR DESCRIPTION
## 개요
자연어 표현을 MongoDB 필터로 변환하는 정책을 정의하고, Hard filter + 단계적 fallback 방식으로 구현합니다.

## 변경 사항
- `docs/06_feature/breed_filtering_policy.md`: 자연어 필터링 정책 문서 (실제 67종 데이터 기반 threshold, 필드 분포, fallback 단계 정의)
- `src/agents/filters/breed_criteria.py`: 조건 추출 + Hard filter + 단계적 fallback (`FilterResult` 반환)
- `src/agents/matchmaker.py`: `FilterResult` 연동 — mongo_filter 주입, fallback 메시지 프롬프트 주입

## Fallback 단계
1. 전체 조건 적용 → 결과 >= 3종이면 완료
2. 수치 threshold ±1 완화
3. 바이너리 조건(hypoallergenic, lap)만 유지
4. 조건 없음 (전체 검색)

## 관련 이슈
- Closes #11
- Closes #12

## 기타

---

- [x] 타입 힌트 작성
- [x] 4-space 들여쓰기 적용
- [x] 관련 이슈 연결