### PR TITLE
docs: ZIPSA FastAPI OpenAPI 3.0 스펙 작성

### DIFF
--- a/docs/04_api/zipsa_openapi.yaml
+++ b/docs/04_api/zipsa_openapi.yaml
@@ -1,0 +1,733 @@
+openapi: 3.0.3
+info:
+  title: ZIPSA API
+  description: AI 기반 고양이 품종 매칭 및 케어 상담 서비스 백엔드 API
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8000/api/v1
+    description: 로컬 개발 서버
+  - url: https://api.zipsa.app/api/v1
+    description: 프로덕션 서버
+
+security:
+  - BearerAuth: []
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: NextAuth.js 발급 JWT 토큰
+
+  schemas:
+    # ── 공통 ──────────────────────────────────────────
+    ErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+          example: "리소스를 찾을 수 없습니다."
+
+    # ── 유저 프로필 ───────────────────────────────────
+    UserPreferences:
+      type: object
+      description: 온보딩 선호 데이터 (MongoDB user_profiles.preferences)
+      properties:
+        housing:
+          type: string
+          enum: [apartment, house, studio]
+        activity:
+          type: string
+          enum: [low, medium, high]
+        experience:
+          type: string
+          enum: [beginner, intermediate, expert]
+        work_style:
+          type: string
+          nullable: true
+        allergy:
+          type: boolean
+        has_children:
+          type: boolean
+        has_dog:
+          type: boolean
+        traits:
+          type: array
+          items:
+            type: string
+        companion:
+          type: array
+          items:
+            type: string
+
+    UserProfileResponse:
+      type: object
+      properties:
+        user_id:
+          type: string
+        email:
+          type: string
+        nickname:
+          type: string
+          nullable: true
+        age:
+          type: integer
+          nullable: true
+        gender:
+          type: string
+          enum: [M, F, 미설정]
+          nullable: true
+        contact:
+          type: string
+          nullable: true
+        address:
+          type: string
+          nullable: true
+        preferences:
+          $ref: '#/components/schemas/UserPreferences'
+        onboarding_completed:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    UserProfileCreateRequest:
+      type: object
+      required: [preferences]
+      properties:
+        nickname:
+          type: string
+        age:
+          type: integer
+          nullable: true
+        gender:
+          type: string
+          enum: [M, F, 미설정]
+          nullable: true
+        contact:
+          type: string
+          nullable: true
+        address:
+          type: string
+          nullable: true
+        preferences:
+          $ref: '#/components/schemas/UserPreferences'
+
+    UserProfileUpdateRequest:
+      type: object
+      properties:
+        nickname:
+          type: string
+        age:
+          type: integer
+          nullable: true
+        gender:
+          type: string
+          enum: [M, F, 미설정]
+          nullable: true
+        contact:
+          type: string
+          nullable: true
+        address:
+          type: string
+          nullable: true
+        preferences:
+          $ref: '#/components/schemas/UserPreferences'
+
+    # ── 고양이 ────────────────────────────────────────
+    Vaccination:
+      type: object
+      properties:
+        type:
+          type: string
+          example: "종합백신 3차"
+        date:
+          type: string
+          format: date
+
+    UserCatResponse:
+      type: object
+      properties:
+        cat_id:
+          type: string
+        user_id:
+          type: string
+        name:
+          type: string
+        age_months:
+          type: integer
+        gender:
+          type: string
+          enum: [M, F, 미상]
+        breed_id:
+          type: string
+          nullable: true
+          description: "67종 중 매핑된 품종 ID. 혼합묘/기타이면 null"
+        breed_name_ko:
+          type: string
+        breed_name_en:
+          type: string
+          nullable: true
+        profile_image_url:
+          type: string
+          nullable: true
+        health:
+          type: object
+          properties:
+            vaccinations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Vaccination'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    UserCatCreateRequest:
+      type: object
+      required: [name, age_months, gender, breed_name_ko]
+      properties:
+        name:
+          type: string
+        age_months:
+          type: integer
+        gender:
+          type: string
+          enum: [M, F, 미상]
+        breed_id:
+          type: string
+          nullable: true
+        breed_name_ko:
+          type: string
+        breed_name_en:
+          type: string
+          nullable: true
+        profile_image_url:
+          type: string
+          nullable: true
+        health:
+          type: object
+          properties:
+            vaccinations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Vaccination'
+
+    UserCatUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        age_months:
+          type: integer
+        gender:
+          type: string
+          enum: [M, F, 미상]
+        breed_id:
+          type: string
+          nullable: true
+        breed_name_ko:
+          type: string
+        breed_name_en:
+          type: string
+          nullable: true
+        profile_image_url:
+          type: string
+          nullable: true
+        health:
+          type: object
+          properties:
+            vaccinations:
+              type: array
+              items:
+                $ref: '#/components/schemas/Vaccination'
+
+    # ── 채팅 세션 ─────────────────────────────────────
+    ChatSessionResponse:
+      type: object
+      properties:
+        session_id:
+          type: string
+        user_id:
+          type: string
+        thread_id:
+          type: string
+        title:
+          type: string
+        last_message:
+          type: string
+          nullable: true
+        message_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    ChatSessionCreateRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+          description: "null이면 첫 메시지 기반 자동 생성"
+
+    # ── 채팅 메시지 ───────────────────────────────────
+    RagDoc:
+      type: object
+      properties:
+        title:
+          type: string
+        subtitle:
+          type: string
+        source:
+          type: string
+        url:
+          type: string
+
+    CatCardStats:
+      type: object
+      additionalProperties:
+        type: number
+
+    Recommendation:
+      type: object
+      properties:
+        name_ko:
+          type: string
+        name_en:
+          type: string
+        image_url:
+          type: string
+        summary:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        stats:
+          $ref: '#/components/schemas/CatCardStats'
+
+    ChatMessageResponse:
+      type: object
+      properties:
+        message_id:
+          type: string
+        session_id:
+          type: string
+        role:
+          type: string
+          enum: [human, ai]
+        content:
+          type: string
+        recommendations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Recommendation'
+        rag_docs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RagDoc'
+        created_at:
+          type: string
+          format: date-time
+
+    ChatInvokeRequest:
+      type: object
+      required: [session_id, message]
+      properties:
+        session_id:
+          type: string
+        message:
+          type: string
+
+    ChatInvokeResponse:
+      type: object
+      properties:
+        message_id:
+          type: string
+        content:
+          type: string
+        recommendations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Recommendation'
+        rag_docs:
+          type: array
+          items:
+            $ref: '#/components/schemas/RagDoc'
+
+    # ── 품종 ──────────────────────────────────────────
+    BreedResponse:
+      type: object
+      properties:
+        breed_id:
+          type: string
+        name_ko:
+          type: string
+        name_en:
+          type: string
+        summary:
+          type: string
+        image_url:
+          type: string
+          nullable: true
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+paths:
+
+  # ── Auth ──────────────────────────────────────────────────────────────────
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: 현재 로그인 유저 정보 조회
+      description: JWT 토큰에서 user_id, email을 추출하여 반환합니다.
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                  email:
+                    type: string
+                  name:
+                    type: string
+                  image:
+                    type: string
+        '401':
+          description: 인증 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ── User Profile ───────────────────────────────────────────────────────────
+  /users/me/profile:
+    get:
+      tags: [User Profile]
+      summary: 내 프로필 조회
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfileResponse'
+        '404':
+          description: 프로필 없음 (온보딩 미완료)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      tags: [User Profile]
+      summary: 프로필 생성 (온보딩 완료)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserProfileCreateRequest'
+      responses:
+        '201':
+          description: 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfileResponse'
+        '409':
+          description: 이미 프로필 존재
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      tags: [User Profile]
+      summary: 프로필 수정
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserProfileUpdateRequest'
+      responses:
+        '200':
+          description: 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfileResponse'
+
+  # ── User Cats ─────────────────────────────────────────────────────────────
+  /users/me/cats:
+    get:
+      tags: [User Cats]
+      summary: 내 고양이 목록 조회
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserCatResponse'
+
+    post:
+      tags: [User Cats]
+      summary: 고양이 등록
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCatCreateRequest'
+      responses:
+        '201':
+          description: 등록 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCatResponse'
+
+  /users/me/cats/{cat_id}:
+    parameters:
+      - name: cat_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    get:
+      tags: [User Cats]
+      summary: 고양이 상세 조회
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCatResponse'
+        '404':
+          description: 고양이 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    put:
+      tags: [User Cats]
+      summary: 고양이 정보 수정
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCatUpdateRequest'
+      responses:
+        '200':
+          description: 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCatResponse'
+
+    delete:
+      tags: [User Cats]
+      summary: 고양이 삭제
+      responses:
+        '204':
+          description: 삭제 성공
+
+  # ── Chat Sessions ─────────────────────────────────────────────────────────
+  /users/me/sessions:
+    get:
+      tags: [Chat Sessions]
+      summary: 채팅 세션 목록 조회
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChatSessionResponse'
+
+    post:
+      tags: [Chat Sessions]
+      summary: 새 채팅 세션 생성
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatSessionCreateRequest'
+      responses:
+        '201':
+          description: 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatSessionResponse'
+
+  /users/me/sessions/{session_id}:
+    parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    get:
+      tags: [Chat Sessions]
+      summary: 세션 상세 조회
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatSessionResponse'
+        '404':
+          description: 세션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Chat Sessions]
+      summary: 세션 삭제
+      description: 세션 및 연결된 메시지, LangGraph 체크포인트를 함께 삭제합니다.
+      responses:
+        '204':
+          description: 삭제 성공
+
+  # ── Chat Messages ─────────────────────────────────────────────────────────
+  /users/me/sessions/{session_id}/messages:
+    parameters:
+      - name: session_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    get:
+      tags: [Chat Messages]
+      summary: 세션 메시지 목록 조회
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+        - name: before
+          in: query
+          schema:
+            type: string
+          description: "커서 기반 페이지네이션: 이 message_id 이전 메시지 조회"
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChatMessageResponse'
+
+  # ── Chat (Agent) ──────────────────────────────────────────────────────────
+  /chat/invoke:
+    post:
+      tags: [Chat]
+      summary: 메시지 전송 (동기 응답)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatInvokeRequest'
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatInvokeResponse'
+
+  /chat/stream:
+    post:
+      tags: [Chat]
+      summary: 메시지 전송 (스트리밍 응답)
+      description: |
+        Server-Sent Events(SSE)로 LangGraph 에이전트 응답을 스트리밍합니다.
+        LangServe `astream_events v2` 기반.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatInvokeRequest'
+      responses:
+        '200':
+          description: SSE 스트림
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: |
+                  이벤트 형식:
+                  - `data: {"type": "token", "content": "..."}` — 텍스트 토큰
+                  - `data: {"type": "recommendations", "data": [...]}` — 품종 카드
+                  - `data: {"type": "rag_docs", "data": [...]}` — 출처
+                  - `data: [DONE]` — 스트림 종료
+
+  # ── Breeds ────────────────────────────────────────────────────────────────
+  /breeds:
+    get:
+      tags: [Breeds]
+      summary: 품종 목록 조회 (67종)
+      description: 드랍다운 및 Interactive Text 자동완성용 품종 리스트
+      security: []
+      parameters:
+        - name: q
+          in: query
+          schema:
+            type: string
+          description: "name_ko 검색 (자동완성용)"
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BreedResponse'


### PR DESCRIPTION
## Summary
- Phase 2.1~2.4 전체 엔드포인트 OpenAPI 3.0.3 스펙 작성
- Auth, User Profile, User Cats, Chat Sessions/Messages, Chat Agent(invoke/stream), Breeds CRUD
- BearerAuth(NextAuth JWT), SSE(`/chat/stream`) 포함

## 포함 엔드포인트
| 태그 | 경로 |
|---|---|
| Auth | `GET /auth/me` |
| User Profile | `GET/POST/PUT /users/me/profile` |
| User Cats | `GET/POST/PUT/DELETE /users/me/cats/{cat_id}` |
| Chat Sessions | `GET/POST/DELETE /users/me/sessions/{session_id}` |
| Chat Messages | `GET /users/me/sessions/{session_id}/messages` |
| Chat | `POST /chat/invoke`, `POST /chat/stream` |
| Breeds | `GET /breeds` |

Refs #17