### PR TITLE
feat: Backend Auth 레이어 구현 — JWT 검증 및 유저 동기화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@ THECATAPI_API_KEY=
 OPENAI_API_KEY=
 MONGO_V3_URI=
 
+# ZIPSA JWT (openssl rand -base64 32)
+ZIPSA_JWT_SECRET=
+
 OPENAPI_API_KEY=
 
 # LangSmith Tracing

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 langserve[all]>=0.2.0
 python-multipart>=0.0.6
+PyJWT>=2.8.0
+certifi

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,13 +1,46 @@
 """
 공통 FastAPI 의존성.
-
-JWT 검증 등 인증 로직은 Issue #20에서 구현 예정.
 """
-from fastapi import HTTPException, status
+import os
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser
+
+_bearer = HTTPBearer()
 
 
-async def get_current_user() -> None:
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="인증 미구현",
-    )
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> AuthUser:
+    """Authorization: Bearer <token> 헤더에서 JWT를 검증하고 AuthUser를 반환합니다."""
+    secret = os.getenv("ZIPSA_JWT_SECRET")
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="서버 설정 오류: JWT 시크릿 미설정",
+        )
+    try:
+        payload = jwt.decode(
+            credentials.credentials,
+            secret,
+            algorithms=[AuthConfig.JWT_ALGORITHM],
+        )
+        user_id: str = payload.get("sub")
+        email: str = payload.get("email")
+        if not user_id or not email:
+            raise ValueError("토큰 페이로드 불완전")
+        return AuthUser(user_id=user_id, email=email)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="토큰이 만료되었습니다.",
+        )
+    except (jwt.InvalidTokenError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="유효하지 않은 토큰입니다.",
+        )

--- a/src/api/routers/auth.py
+++ b/src/api/routers/auth.py
@@ -1,8 +1,93 @@
 """
-/api/v1/auth — 인증 라우터 (stub)
+/api/v1/auth — 인증 라우터
 
-TODO: Issue #25 — NextAuth.js SSO 연동 (Google/Kakao/Naver)
+POST /api/v1/auth/sync  — NextAuth 세션 → MongoDB upsert → ZIPSA JWT 발급
+GET  /api/v1/auth/me    — 현재 로그인 유저 정보 조회
 """
-from fastapi import APIRouter
+import logging
+import os
+from datetime import datetime, timedelta, timezone
 
+import certifi
+import jwt
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser, MeResponse, SyncRequest, SyncResponse
+from src.api.dependencies import get_current_user
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/auth", tags=["Auth"])
+
+
+def _get_users_collection():
+    uri = os.getenv("MONGO_V3_URI")
+    client = AsyncIOMotorClient(uri, tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["users"]
+
+
+def _issue_token(user_id: str, email: str) -> str:
+    secret = os.getenv("ZIPSA_JWT_SECRET")
+    payload = {
+        "sub": user_id,
+        "email": email,
+        "exp": datetime.now(timezone.utc) + timedelta(days=AuthConfig.JWT_EXPIRE_DAYS),
+    }
+    return jwt.encode(payload, secret, algorithm=AuthConfig.JWT_ALGORITHM)
+
+
+@router.post("/sync", response_model=SyncResponse, status_code=status.HTTP_200_OK)
+async def sync_user(body: SyncRequest) -> SyncResponse:
+    """
+    NextAuth 로그인 후 호출. users 컬렉션에 upsert하고 ZIPSA JWT를 반환합니다.
+    """
+    collection = _get_users_collection()
+    now = datetime.now(timezone.utc)
+
+    result = await collection.find_one_and_update(
+        {"email": body.email},
+        {
+            "$set": {
+                "email": body.email,
+                "name": body.name,
+                "image": body.image,
+                "provider": body.provider,
+                "updated_at": now,
+            },
+            "$setOnInsert": {"created_at": now},
+        },
+        upsert=True,
+        return_document=True,
+    )
+
+    user_id = str(result["_id"])
+    access_token = _issue_token(user_id, body.email)
+
+    return SyncResponse(
+        access_token=access_token,
+        user_id=user_id,
+        email=body.email,
+    )
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(current_user: AuthUser = Depends(get_current_user)) -> MeResponse:
+    """JWT에서 user_id를 추출해 MongoDB에서 유저 정보를 조회합니다."""
+    collection = _get_users_collection()
+    try:
+        doc = await collection.find_one({"_id": ObjectId(current_user.user_id)})
+    except Exception:
+        doc = None
+
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="유저를 찾을 수 없습니다.")
+
+    return MeResponse(
+        user_id=str(doc["_id"]),
+        email=doc.get("email", current_user.email),
+        name=doc.get("name"),
+        image=doc.get("image"),
+        provider=doc.get("provider"),
+    )

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -53,6 +53,14 @@ class TokenConfig:
     MAX_TOKENS_PER_TURN: int = 1000
 
 
+class AuthConfig:
+    # ZIPSA 자체 발급 JWT 설정
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRE_DAYS: int = 30
+    # 유저 데이터 MongoDB 데이터베이스명
+    USER_DB_NAME: str = "zipsa"
+
+
 class LLMConfig:
     # 기본 분류/라우팅용 (속도/비용 최적화)
     ROUTER_MODEL = "gpt-4.1-nano"

--- a/src/core/models/auth.py
+++ b/src/core/models/auth.py
@@ -1,0 +1,36 @@
+"""
+인증 관련 Pydantic 모델.
+"""
+from pydantic import BaseModel, EmailStr, Field
+from typing import Optional
+
+
+class AuthUser(BaseModel):
+    """JWT에서 추출한 인증된 유저 정보."""
+    user_id: str = Field(description="MongoDB users._id (문자열)")
+    email: str = Field(description="OAuth 이메일")
+
+
+class SyncRequest(BaseModel):
+    """POST /auth/sync — NextAuth 세션 정보."""
+    email: str = Field(description="OAuth 이메일")
+    name: Optional[str] = Field(default=None, description="표시 이름")
+    image: Optional[str] = Field(default=None, description="프로필 이미지 URL")
+    provider: str = Field(description="OAuth 프로바이더 (google | kakao | naver)")
+
+
+class SyncResponse(BaseModel):
+    """POST /auth/sync 응답 — ZIPSA 액세스 토큰."""
+    access_token: str
+    token_type: str = "bearer"
+    user_id: str
+    email: str
+
+
+class MeResponse(BaseModel):
+    """GET /auth/me 응답."""
+    user_id: str
+    email: str
+    name: Optional[str] = None
+    image: Optional[str] = None
+    provider: Optional[str] = None


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/sync` — NextAuth 세션 → MongoDB `zipsa.users` upsert → ZIPSA JWT(HS256) 발급
- `GET /api/v1/auth/me` — JWT 검증 후 유저 정보 반환
- `get_current_user()` 의존성 구현 (HTTPBearer + PyJWT)
- `AuthConfig` — JWT 알고리즘, 만료 기간, DB명 설정
- `ZIPSA_JWT_SECRET` 환경 변수 추가 (`.env.example`)

## Test
- `POST /sync` → 200 + access_token 확인
- Swagger Authorize → `GET /me` → 200 확인

## Closes
Closes #26