### PR TITLE
feat: 프로필 완성 API 구현 — GET/POST/PUT /users/me/profile

### DIFF
--- a/src/api/routers/users.py
+++ b/src/api/routers/users.py
@@ -1,8 +1,108 @@
 """
-/api/v1/users — 유저 프로필 라우터 (stub)
-
-TODO: Issue #28 — 프로필 완성 API 구현
+/api/v1/users — 유저 프로필 라우터
 """
-from fastapi import APIRouter
+import logging
+import os
+from datetime import datetime, timezone
 
+import certifi
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.api.dependencies import get_current_user
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser
+from src.core.models.profile import (
+    UserProfileCreateRequest,
+    UserProfileResponse,
+    UserProfileUpdateRequest,
+)
+
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/users", tags=["Users"])
+
+
+def _get_profiles_collection():
+    uri = os.getenv("MONGO_V3_URI")
+    client = AsyncIOMotorClient(uri, tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["user_profiles"]
+
+
+def _get_users_collection():
+    uri = os.getenv("MONGO_V3_URI")
+    client = AsyncIOMotorClient(uri, tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["users"]
+
+
+def _doc_to_response(doc: dict, email: str) -> UserProfileResponse:
+    return UserProfileResponse(
+        user_id=str(doc["user_id"]),
+        email=email,
+        nickname=doc.get("nickname"),
+        age=doc.get("age"),
+        gender=doc.get("gender"),
+        contact=doc.get("contact"),
+        address=doc.get("address"),
+        preferences=doc.get("preferences", {}),
+        onboarding_completed=doc.get("onboarding_completed", False),
+        created_at=doc["created_at"],
+        updated_at=doc["updated_at"],
+    )
+
+
+@router.get("/me/profile", response_model=UserProfileResponse)
+async def get_profile(
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserProfileResponse:
+    """내 프로필 조회. 없으면 404."""
+    profiles = _get_profiles_collection()
+    doc = await profiles.find_one({"user_id": current_user.user_id})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="프로필 없음 (온보딩 미완료)")
+    return _doc_to_response(doc, current_user.email)
+
+
+@router.post("/me/profile", response_model=UserProfileResponse, status_code=status.HTTP_201_CREATED)
+async def create_profile(
+    body: UserProfileCreateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserProfileResponse:
+    """프로필 생성 (온보딩 완료). 이미 존재하면 409."""
+    profiles = _get_profiles_collection()
+    existing = await profiles.find_one({"user_id": current_user.user_id})
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="이미 프로필이 존재합니다.")
+
+    now = datetime.now(timezone.utc)
+    doc = {
+        "user_id": current_user.user_id,
+        **body.model_dump(),
+        "onboarding_completed": True,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await profiles.insert_one(doc)
+    return _doc_to_response(doc, current_user.email)
+
+
+@router.put("/me/profile", response_model=UserProfileResponse)
+async def update_profile(
+    body: UserProfileUpdateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserProfileResponse:
+    """프로필 수정. 없으면 404."""
+    profiles = _get_profiles_collection()
+    now = datetime.now(timezone.utc)
+
+    update_fields = {k: v for k, v in body.model_dump().items() if v is not None}
+    update_fields["updated_at"] = now
+
+    doc = await profiles.find_one_and_update(
+        {"user_id": current_user.user_id},
+        {"$set": update_fields},
+        return_document=True,
+    )
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="프로필 없음 (온보딩 미완료)")
+    return _doc_to_response(doc, current_user.email)

--- a/src/core/models/profile.py
+++ b/src/core/models/profile.py
@@ -1,0 +1,56 @@
+"""
+프로필 API Pydantic 모델.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class UserPreferences(BaseModel):
+    """온보딩 선호 데이터."""
+    housing: str = Field(default="apartment")
+    activity: str = Field(default="low")
+    experience: str = Field(default="beginner")
+    work_style: Optional[str] = None
+    allergy: bool = False
+    has_children: bool = False
+    has_dog: bool = False
+    has_cat: bool = False
+    traits: List[str] = Field(default_factory=list)
+    companion: List[str] = Field(default_factory=list)
+
+
+class UserProfileCreateRequest(BaseModel):
+    """POST /users/me/profile 요청."""
+    nickname: Optional[str] = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+    contact: Optional[str] = None
+    address: Optional[str] = None
+    preferences: UserPreferences = Field(default_factory=UserPreferences)
+
+
+class UserProfileUpdateRequest(BaseModel):
+    """PUT /users/me/profile 요청 — 모든 필드 선택적."""
+    nickname: Optional[str] = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+    contact: Optional[str] = None
+    address: Optional[str] = None
+    preferences: Optional[UserPreferences] = None
+
+
+class UserProfileResponse(BaseModel):
+    """프로필 응답."""
+    user_id: str
+    email: str
+    nickname: Optional[str] = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+    contact: Optional[str] = None
+    address: Optional[str] = None
+    preferences: UserPreferences = Field(default_factory=UserPreferences)
+    onboarding_completed: bool = False
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
## Summary
- `GET /api/v1/users/me/profile` — 프로필 조회 (없으면 404)
- `POST /api/v1/users/me/profile` — 프로필 생성, `onboarding_completed: true` 저장 (중복 시 409)
- `PUT /api/v1/users/me/profile` — 프로필 수정
- `src/core/models/profile.py` — `UserPreferences`, `UserProfileCreateRequest`, `UserProfileUpdateRequest`, `UserProfileResponse`
- MongoDB: `zipsa.user_profiles` 컬렉션

## Test
- Swagger에서 JWT 인증 후 POST → GET → PUT 순서로 검증 완료

## Closes
Closes #28