### PR TITLE
feat: MemorySaver → MongoDBSaver 교체 및 Chat/Session API 구현

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ numpy
 nbstripout
 fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
-langserve[all]>=0.2.0
 python-multipart>=0.0.6
 PyJWT>=2.8.0
 certifi
+langgraph-checkpoint-mongodb

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -2,8 +2,12 @@
 LangGraph 워크플로우 정의 (고양이 집사 서비스)
 4노드 아키텍처: head_butler → matchmaker | liaison | care
 """
+import os
+
+import certifi
+from pymongo import MongoClient
 from langgraph.graph import StateGraph, START, END
-from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.mongodb import MongoDBSaver
 from langgraph.prebuilt import ToolNode
 
 from .state import AgentState
@@ -31,7 +35,8 @@ def create_zipsa_graph():
     아래 정의된 static edges는 주로 그래프 시각화 및 구조 명시용으로 작동합니다.
     """
 
-    memory = MemorySaver()
+    mongo_client = MongoClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    checkpointer = MongoDBSaver(mongo_client)
     workflow = StateGraph(AgentState)
 
     # 1. 노드 등록 (Node Registration)
@@ -82,7 +87,7 @@ def create_zipsa_graph():
     # 케어팀 -> 수석 집사
     workflow.add_edge("care", "head_butler")
 
-    return workflow.compile(checkpointer=memory)
+    return workflow.compile(checkpointer=checkpointer)
 
 
 # 앱 인스턴스 생성 및 내보내기

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -1,39 +1,155 @@
 """
-/api/v1/chat — LangServe 라우터
+/api/v1/chat — 커스텀 채팅 엔드포인트
 
-LangServe add_routes가 자동 생성하는 엔드포인트:
-  POST /api/v1/chat/invoke          — 동기 응답
-  POST /api/v1/chat/stream          — SSE 스트리밍
-  POST /api/v1/chat/stream_events   — astream_events v2
-  GET  /api/v1/chat/input_schema    — 입력 스키마
-  GET  /api/v1/chat/output_schema   — 출력 스키마
-
-Note:
-  AgentState가 Dict[str, Any] 서브클래스라 Pydantic v2가 JSON 스키마를
-  자동 생성할 수 없으므로, 명시적 ChatInput 모델을 input_type으로 전달한다.
-  LangServe는 이를 dict로 변환하여 그래프에 전달하므로 동작에는 영향 없음.
+POST /api/v1/chat/invoke  — 동기 응답
+POST /api/v1/chat/stream  — SSE 스트리밍
 """
-from typing import Any, Dict, List
+import json
+import logging
+import os
+from datetime import datetime, timezone
 
-from fastapi import APIRouter
-from langserve import add_routes
-from pydantic import BaseModel
+import certifi
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+from langchain_core.messages import HumanMessage, AIMessage
+from motor.motor_asyncio import AsyncIOMotorClient
 
 from src.agents.graph import app as graph_app
-
-
-class ChatInput(BaseModel):
-    """LangServe /invoke, /stream 공통 입력 스키마."""
-
-    messages: List[Dict[str, Any]]
-    user_profile: Dict[str, Any] = {}
-
-
-router = APIRouter()
-add_routes(
-    router,
-    graph_app,
-    path="/api/v1/chat",
-    input_type=ChatInput,
-    config_keys=["configurable"],  # thread_id 등 LangGraph 체크포인터 설정 전달
+from src.api.dependencies import get_current_user
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser
+from src.core.models.chat import (
+    ChatInvokeRequest,
+    ChatInvokeResponse,
+    RagDoc,
+    Recommendation,
 )
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/chat", tags=["Chat"])
+
+
+def _get_sessions_col():
+    client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["chat_sessions"]
+
+
+async def _get_session_or_404(session_id: str, user_id: str) -> dict:
+    col = _get_sessions_col()
+    doc = await col.find_one({"_id": ObjectId(session_id), "user_id": user_id})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
+    return doc
+
+
+async def _update_session_meta(session_id: str, last_message: str, increment: int = 2) -> None:
+    """세션의 last_message, message_count, updated_at 갱신."""
+    col = _get_sessions_col()
+    await col.update_one(
+        {"_id": ObjectId(session_id)},
+        {
+            "$set": {"last_message": last_message, "updated_at": datetime.now(timezone.utc)},
+            "$inc": {"message_count": increment},
+        },
+    )
+
+
+@router.post("/invoke", response_model=ChatInvokeResponse)
+async def invoke_chat(
+    body: ChatInvokeRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> ChatInvokeResponse:
+    """동기 채팅 응답."""
+    session = await _get_session_or_404(body.session_id, current_user.user_id)
+    thread_id = session["thread_id"]
+
+    result = await graph_app.ainvoke(
+        {
+            "messages": [HumanMessage(content=body.message)],
+            "user_profile": {},
+        },
+        config={"configurable": {"thread_id": thread_id}},
+    )
+
+    # 마지막 AIMessage 추출
+    ai_messages = [m for m in result.get("messages", []) if isinstance(m, AIMessage)]
+    if not ai_messages:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="응답 생성 실패")
+
+    last_ai = ai_messages[-1]
+    content = last_ai.content if isinstance(last_ai.content, str) else str(last_ai.content)
+
+    rag_docs = [RagDoc(**d) if isinstance(d, dict) else d for d in result.get("rag_docs", [])]
+    recommendations = [
+        Recommendation(**r) if isinstance(r, dict) else r
+        for r in result.get("recommendations", [])
+    ]
+
+    await _update_session_meta(body.session_id, body.message)
+
+    message_id = f"{thread_id}-{len(result.get('messages', []))}"
+    return ChatInvokeResponse(
+        message_id=message_id,
+        content=content,
+        recommendations=recommendations,
+        rag_docs=rag_docs,
+    )
+
+
+@router.post("/stream")
+async def stream_chat(
+    body: ChatInvokeRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> StreamingResponse:
+    """SSE 스트리밍 채팅 응답."""
+    session = await _get_session_or_404(body.session_id, current_user.user_id)
+    thread_id = session["thread_id"]
+
+    async def event_generator():
+        full_content = ""
+        rag_docs = []
+        recommendations = []
+
+        try:
+            async for event in graph_app.astream_events(
+                {
+                    "messages": [HumanMessage(content=body.message)],
+                    "user_profile": {},
+                },
+                config={"configurable": {"thread_id": thread_id}},
+                version="v2",
+            ):
+                kind = event.get("event")
+                tags = event.get("tags", [])
+
+                # router_classification 태그 필터링 (내부 LLM 호출 제외)
+                if "router_classification" in tags:
+                    continue
+
+                if kind == "on_chat_model_stream":
+                    chunk = event["data"].get("chunk")
+                    if chunk and hasattr(chunk, "content") and chunk.content:
+                        full_content += chunk.content
+                        yield f"data: {json.dumps({'type': 'token', 'content': chunk.content})}\n\n"
+
+                elif kind == "on_chain_end":
+                    output = event.get("data", {}).get("output", {})
+                    if isinstance(output, dict):
+                        if output.get("rag_docs"):
+                            rag_docs = output["rag_docs"]
+                            yield f"data: {json.dumps({'type': 'rag_docs', 'data': rag_docs})}\n\n"
+                        if output.get("recommendations"):
+                            recommendations = output["recommendations"]
+                            yield f"data: {json.dumps({'type': 'recommendations', 'data': recommendations})}\n\n"
+
+        except Exception:
+            logger.exception("stream_chat 오류")
+            yield f"data: {json.dumps({'type': 'error', 'content': '응답 생성 중 오류가 발생했습니다.'})}\n\n"
+        finally:
+            if full_content:
+                await _update_session_meta(body.session_id, body.message)
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/src/api/routers/sessions.py
+++ b/src/api/routers/sessions.py
@@ -1,0 +1,150 @@
+"""
+/api/v1/users/me/sessions — 채팅 세션 CRUD
+"""
+import logging
+import os
+from datetime import datetime, timezone
+
+import certifi
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from langchain_core.messages import AIMessage, HumanMessage
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.api.dependencies import get_current_user
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser
+from src.core.models.chat import (
+    ChatMessageResponse,
+    ChatSessionCreateRequest,
+    ChatSessionResponse,
+    RagDoc,
+    Recommendation,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/users/me/sessions", tags=["Chat Sessions"])
+
+
+def _get_sessions_col():
+    client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["chat_sessions"]
+
+
+def _get_checkpoints_col():
+    client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    return client["zipsa"]["checkpoints"]
+
+
+def _doc_to_response(doc: dict) -> ChatSessionResponse:
+    return ChatSessionResponse(
+        session_id=str(doc["_id"]),
+        user_id=doc["user_id"],
+        thread_id=doc["thread_id"],
+        title=doc.get("title"),
+        last_message=doc.get("last_message"),
+        message_count=doc.get("message_count", 0),
+        created_at=doc["created_at"],
+        updated_at=doc["updated_at"],
+    )
+
+
+@router.get("", response_model=list[ChatSessionResponse])
+async def list_sessions(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: AuthUser = Depends(get_current_user),
+) -> list[ChatSessionResponse]:
+    col = _get_sessions_col()
+    cursor = col.find({"user_id": current_user.user_id}).sort("updated_at", -1).skip(offset).limit(limit)
+    return [_doc_to_response(doc) async for doc in cursor]
+
+
+@router.post("", response_model=ChatSessionResponse, status_code=status.HTTP_201_CREATED)
+async def create_session(
+    body: ChatSessionCreateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> ChatSessionResponse:
+    col = _get_sessions_col()
+    now = datetime.now(timezone.utc)
+    doc = {
+        "user_id": current_user.user_id,
+        "title": body.title,
+        "last_message": None,
+        "message_count": 0,
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = await col.insert_one(doc)
+    doc["_id"] = result.inserted_id
+    # thread_id = session_id (LangGraph MongoDBSaver 연동)
+    session_id = str(result.inserted_id)
+    await col.update_one({"_id": result.inserted_id}, {"$set": {"thread_id": session_id}})
+    doc["thread_id"] = session_id
+    return _doc_to_response(doc)
+
+
+@router.get("/{session_id}", response_model=ChatSessionResponse)
+async def get_session(
+    session_id: str,
+    current_user: AuthUser = Depends(get_current_user),
+) -> ChatSessionResponse:
+    col = _get_sessions_col()
+    doc = await col.find_one({"_id": ObjectId(session_id), "user_id": current_user.user_id})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
+    return _doc_to_response(doc)
+
+
+@router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: str,
+    current_user: AuthUser = Depends(get_current_user),
+) -> None:
+    col = _get_sessions_col()
+    result = await col.delete_one({"_id": ObjectId(session_id), "user_id": current_user.user_id})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
+    # LangGraph 체크포인트 삭제
+    checkpoints = _get_checkpoints_col()
+    await checkpoints.delete_many({"thread_id": session_id})
+
+
+@router.get("/{session_id}/messages", response_model=list[ChatMessageResponse])
+async def list_messages(
+    session_id: str,
+    limit: int = Query(default=50, ge=1, le=200),
+    current_user: AuthUser = Depends(get_current_user),
+) -> list[ChatMessageResponse]:
+    """LangGraph MongoDBSaver 체크포인트에서 메시지 복원."""
+    col = _get_sessions_col()
+    session = await col.find_one({"_id": ObjectId(session_id), "user_id": current_user.user_id})
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
+
+    from src.agents.graph import app as graph_app
+    state = await graph_app.aget_state({"configurable": {"thread_id": session_id}})
+    if not state or not state.values:
+        return []
+
+    messages = state.values.get("messages", [])
+    result = []
+    for i, msg in enumerate(messages[-limit:]):
+        role = "human" if isinstance(msg, HumanMessage) else "ai"
+        rag_docs = []
+        recommendations = []
+        if isinstance(msg, AIMessage):
+            for doc in state.values.get("rag_docs", []):
+                rag_docs.append(RagDoc(**doc) if isinstance(doc, dict) else doc)
+            for rec in state.values.get("recommendations", []):
+                recommendations.append(Recommendation(**rec) if isinstance(rec, dict) else rec)
+        result.append(ChatMessageResponse(
+            message_id=f"{session_id}-{i}",
+            session_id=session_id,
+            role=role,
+            content=msg.content if isinstance(msg.content, str) else str(msg.content),
+            recommendations=recommendations,
+            rag_docs=rag_docs,
+            created_at=session["created_at"],
+        ))
+    return result

--- a/src/core/models/chat.py
+++ b/src/core/models/chat.py
@@ -1,0 +1,66 @@
+"""
+채팅 세션 및 메시지 Pydantic 모델.
+"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ── 세션 ──────────────────────────────────────────────────────────────────────
+
+class ChatSessionCreateRequest(BaseModel):
+    title: Optional[str] = Field(default=None, description="null이면 첫 메시지 기반 자동 생성")
+
+
+class ChatSessionResponse(BaseModel):
+    session_id: str
+    user_id: str
+    thread_id: str
+    title: Optional[str] = None
+    last_message: Optional[str] = None
+    message_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+# ── 메시지 ─────────────────────────────────────────────────────────────────────
+
+class RagDoc(BaseModel):
+    title: str = ""
+    subtitle: str = ""
+    source: str = ""
+    url: str = ""
+
+
+class Recommendation(BaseModel):
+    name_ko: str = ""
+    name_en: Optional[str] = None
+    image_url: Optional[str] = None
+    summary: str = ""
+    tags: List[str] = Field(default_factory=list)
+    stats: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatMessageResponse(BaseModel):
+    message_id: str
+    session_id: str
+    role: str  # "human" | "ai"
+    content: str
+    recommendations: List[Recommendation] = Field(default_factory=list)
+    rag_docs: List[RagDoc] = Field(default_factory=list)
+    created_at: datetime
+
+
+# ── Chat 호출 ─────────────────────────────────────────────────────────────────
+
+class ChatInvokeRequest(BaseModel):
+    session_id: str
+    message: str
+
+
+class ChatInvokeResponse(BaseModel):
+    message_id: str
+    content: str
+    recommendations: List[Recommendation] = Field(default_factory=list)
+    rag_docs: List[RagDoc] = Field(default_factory=list)

--- a/src/main.py
+++ b/src/main.py
@@ -5,11 +5,20 @@ ZIPSA FastAPI 서버 엔트리포인트
   uvicorn src.main:app --reload --port 8000
 
 엔드포인트:
-  GET  /health                      — 헬스 체크
-  GET  /docs                        — Swagger UI
-  POST /api/v1/chat/invoke          — 동기 응답
-  POST /api/v1/chat/stream          — SSE 스트리밍
-  POST /api/v1/chat/stream_events   — astream_events v2
+  GET  /health                                    — 헬스 체크
+  GET  /docs                                      — Swagger UI
+  POST /api/v1/auth/sync                          — NextAuth 동기화 & JWT 발급
+  GET  /api/v1/auth/me                            — 현재 유저 정보
+  GET  /api/v1/users/me/profile                   — 프로필 조회
+  POST /api/v1/users/me/profile                   — 프로필 생성
+  PUT  /api/v1/users/me/profile                   — 프로필 수정
+  GET  /api/v1/users/me/sessions                  — 세션 목록
+  POST /api/v1/users/me/sessions                  — 세션 생성
+  GET  /api/v1/users/me/sessions/{id}             — 세션 상세
+  DELETE /api/v1/users/me/sessions/{id}           — 세션 삭제
+  GET  /api/v1/users/me/sessions/{id}/messages    — 메시지 목록
+  POST /api/v1/chat/invoke                        — 동기 채팅
+  POST /api/v1/chat/stream                        — SSE 스트리밍
 """
 from pathlib import Path
 
@@ -19,7 +28,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 load_dotenv(Path(__file__).parents[1] / ".env")
 
-from src.api.routers import auth, chat, meme, users
+from src.api.routers import auth, chat, meme, sessions, users
 
 app = FastAPI(
     title="ZIPSA API",
@@ -35,9 +44,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(chat.router)
 app.include_router(auth.router)
 app.include_router(users.router)
+app.include_router(sessions.router)
+app.include_router(chat.router)
 app.include_router(meme.router)
 
 


### PR DESCRIPTION
## Summary

### Commit 1 — MemorySaver → MongoDBSaver
- `src/agents/graph.py`: `MemorySaver` → `MongoDBSaver` 교체
- 서버 재시작 후에도 채팅 세션 영속성 확보
- `requirements.txt`: `langgraph-checkpoint-mongodb` 추가

### Commit 2 — LangServe 제거 및 Chat/Session API 구현
- `langserve` 제거 → 커스텀 FastAPI 엔드포인트로 교체
- `src/core/models/chat.py`: ChatSession, ChatMessage, ChatInvokeRequest/Response 모델
- `src/api/routers/sessions.py`: GET/POST/DELETE 세션 CRUD + 메시지 목록
- `src/api/routers/chat.py`: `POST /invoke` (동기) + `POST /stream` (SSE)
- `src/main.py`: sessions 라우터 등록, 엔드포인트 목록 업데이트

## Test
Swagger에서 sync → create session → invoke chat 순서로 검증 완료

## Closes
Closes #32, Closes #33