### PR TITLE
feat: 채팅 페이지 구현 및 Zustand 전역 상태 관리 도입

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "react-daum-postcode": "^4.0.0",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7883,6 +7884,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "react-daum-postcode": "^4.0.0",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -76,6 +76,7 @@ export default function ChatSessionPage() {
   const [ragDocs, setRagDocs] = useState<RagDoc[]>([]);
   const [selectedBreed, setSelectedBreed] = useState(0);
   const [sessionTitle, setSessionTitle] = useState("새 대화");
+  const [creating, setCreating] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);          // handleSend 중복 실행 방지
   const loadedSessionRef = useRef<string | null>(null); // getMessages 중복 호출 방지
@@ -120,14 +121,17 @@ export default function ChatSessionPage() {
 
     // 새 채팅이면 첫 메시지 전송 시 세션 생성
     if (!resolvedIdRef.current) {
+      setCreating(true);
       try {
         const session = await createSession(token);
         resolvedIdRef.current = session.session_id;
         addSession(session);
       } catch {
+        setCreating(false);
         sendingRef.current = false;
         return;
       }
+      setCreating(false);
     }
     const activeSessionId = resolvedIdRef.current;
 
@@ -231,6 +235,19 @@ export default function ChatSessionPage() {
               ),
             )}
 
+            {/* 세션 생성 중 로딩 */}
+            {creating && (
+              <div className="flex justify-center">
+                <div className="bg-white border-2 border-gray-200 rounded-2xl px-4 py-3">
+                  <span className="inline-flex gap-1 items-center">
+                    <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "0ms" }} />
+                    <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "150ms" }} />
+                    <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "300ms" }} />
+                  </span>
+                </div>
+              </div>
+            )}
+
             {/* 스트리밍 중인 AI 메시지 */}
             {streaming && (
               <div className="flex justify-start gap-3">
@@ -254,19 +271,19 @@ export default function ChatSessionPage() {
           </div>
 
           <div className="border-t-2 border-gray-300 p-4">
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-stretch">
               <Input
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="메시지를 입력하세요..."
-                disabled={streaming}
-                className="flex-1 border-2 border-gray-300 focus:border-gray-900 rounded-lg px-4 py-2"
+                disabled={streaming || creating}
+                className="flex-1 h-10 border-2 border-gray-300 focus:border-gray-900 rounded-lg px-4"
               />
               <Button
                 onClick={handleSend}
-                disabled={streaming || !input.trim()}
-                className="bg-gray-900 text-white hover:bg-gray-800 px-4 disabled:opacity-50"
+                disabled={streaming || creating || !input.trim()}
+                className="h-10 bg-gray-900 text-white hover:bg-gray-800 px-4 disabled:opacity-50"
               >
                 <Send className="w-5 h-5" />
               </Button>

--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { ArrowLeft, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Navigation } from "@/components/layout/Navigation";
+import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
+import { BreedPopover } from "@/components/BreedPopover";
+import { CatCard } from "@/components/chat/CatCard";
+import {
+  getZipsaToken,
+  createSession,
+  getMessages,
+  streamChat,
+  type ChatMessage,
+  type Recommendation,
+  type RagDoc,
+} from "@/lib/api";
+import { useZipsaStore } from "@/store/zipsa";
+
+// ── AI 메시지 내 품종명 → BreedPopover 인라인 렌더링 ───────────────────────
+
+function renderWithPopovers(
+  content: string,
+  recommendations: Recommendation[],
+  onViewDetails: (nameKo: string) => void,
+): React.ReactNode {
+  if (!recommendations.length) return content;
+
+  const names = recommendations.map((r) => r.name_ko).filter(Boolean);
+  if (!names.length) return content;
+
+  const escaped = names.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const pattern = new RegExp(`(${escaped.join("|")})`, "g");
+  const parts = content.split(pattern);
+
+  return parts.map((part, i) => {
+    const rec = recommendations.find((r) => r.name_ko === part);
+    if (rec) {
+      return (
+        <BreedPopover
+          key={i}
+          triggerText={part}
+          breedKorean={rec.name_ko}
+          breedEnglish={rec.name_en}
+          tags={rec.tags}
+          summary={rec.summary}
+          onViewDetails={() => onViewDetails(rec.name_ko)}
+        />
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+// ── 컴포넌트 ─────────────────────────────────────────────────────────────────
+
+export default function ChatSessionPage() {
+  const router = useRouter();
+  const params = useParams();
+  const paramId = params.id as string;
+  const isNew = paramId === "new";
+  const resolvedIdRef = useRef<string | null>(isNew ? null : paramId);
+  const profile = useZipsaStore((s) => s.profile);
+  const addSession = useZipsaStore((s) => s.addSession);
+  const updateSession = useZipsaStore((s) => s.updateSession);
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [streamContent, setStreamContent] = useState("");
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [ragDocs, setRagDocs] = useState<RagDoc[]>([]);
+  const [selectedBreed, setSelectedBreed] = useState(0);
+  const [sessionTitle, setSessionTitle] = useState("새 대화");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const sendingRef = useRef(false);          // handleSend 중복 실행 방지
+  const loadedSessionRef = useRef<string | null>(null); // getMessages 중복 호출 방지
+
+  // 메시지 로드 (기존 세션만, 세션당 1회)
+  useEffect(() => {
+    if (isNew) return;
+    if (loadedSessionRef.current === paramId) return;
+    loadedSessionRef.current = paramId;
+    const token = getZipsaToken();
+    if (!token) return;
+    getMessages(token, paramId)
+      .then((msgs) => {
+        setMessages(msgs);
+        const lastAI = [...msgs].reverse().find((m) => m.role === "ai");
+        if (lastAI) {
+          if (lastAI.recommendations?.length) setRecommendations(lastAI.recommendations);
+          if (lastAI.rag_docs?.length) setRagDocs(lastAI.rag_docs);
+        }
+        const firstHuman = msgs.find((m) => m.role === "human");
+        if (firstHuman) setSessionTitle(firstHuman.content.slice(0, 30));
+      })
+      .catch(() => {});
+  }, [paramId, isNew]);
+
+  // 자동 스크롤
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamContent]);
+
+  const handleViewDetails = useCallback((nameKo: string) => {
+    const idx = recommendations.findIndex((r) => r.name_ko === nameKo);
+    if (idx >= 0) setSelectedBreed(idx);
+  }, [recommendations]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || streaming || sendingRef.current) return;
+    sendingRef.current = true;
+    const token = getZipsaToken();
+    if (!token) { sendingRef.current = false; return; }
+
+    // 새 채팅이면 첫 메시지 전송 시 세션 생성
+    if (!resolvedIdRef.current) {
+      try {
+        const session = await createSession(token);
+        resolvedIdRef.current = session.session_id;
+        addSession(session);
+      } catch {
+        sendingRef.current = false;
+        return;
+      }
+    }
+    const activeSessionId = resolvedIdRef.current;
+
+    setInput("");
+    const userMsg: ChatMessage = {
+      message_id: crypto.randomUUID(),
+      session_id: activeSessionId,
+      role: "human",
+      content: text,
+      recommendations: [],
+      rag_docs: [],
+      created_at: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setStreaming(true);
+    setStreamContent("");
+
+    let fullContent = "";
+    let newRecs: Recommendation[] = [];
+    let newDocs: RagDoc[] = [];
+
+    try {
+      for await (const event of streamChat(token, activeSessionId, text, profile)) {
+        if (event.type === "token" && typeof event.content === "string") {
+          fullContent += event.content;
+          setStreamContent(fullContent);
+        } else if (event.type === "recommendations" && Array.isArray(event.data)) {
+          newRecs = event.data as Recommendation[];
+          setRecommendations(newRecs);
+          setSelectedBreed(0);
+        } else if (event.type === "rag_docs" && Array.isArray(event.data)) {
+          newDocs = event.data as RagDoc[];
+          setRagDocs(newDocs);
+        }
+      }
+    } catch (err) {
+      console.error("스트리밍 오류:", err);
+    } finally {
+      const aiMsg: ChatMessage = {
+        message_id: crypto.randomUUID(),
+        session_id: activeSessionId,
+        role: "ai",
+        content: fullContent,
+        recommendations: newRecs,
+        rag_docs: newDocs,
+        created_at: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, aiMsg]);
+      setStreamContent("");
+      setStreaming(false);
+      sendingRef.current = false;
+      if (messages.length === 0) setSessionTitle(text.slice(0, 30));
+      // store 세션 업데이트 (제목 + message_count)
+      updateSession(activeSessionId, { title: text.slice(0, 30), message_count: 1 });
+      // 새 채팅이었으면 스트리밍 완료 후 URL 확정
+      if (isNew) router.replace(`/chat/${activeSessionId}`);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend(); }
+  };
+
+  return (
+    <div className="h-screen w-full flex flex-col bg-white">
+      <Navigation onMenuClick={() => setDrawerOpen(true)} fullWidth hideNewChat />
+      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      <div className="flex-1 flex overflow-hidden">
+        {/* 채팅 영역 */}
+        <div className="flex-1 flex flex-col border-r-2 border-gray-300">
+          <div className="h-16 px-4 border-b-2 border-gray-300 flex items-center gap-3">
+            <button
+              onClick={() => router.back()}
+              className="p-2 hover:bg-gray-100 rounded transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </button>
+            <h2 className="text-lg font-bold text-gray-900 truncate">{sessionTitle}</h2>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            {messages.map((msg) =>
+              msg.role === "human" ? (
+                <div key={msg.message_id} className="flex justify-end">
+                  <div className="bg-gray-200 border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-md">
+                    <p className="text-gray-900 text-sm leading-relaxed">{msg.content}</p>
+                  </div>
+                </div>
+              ) : (
+                <div key={msg.message_id} className="flex justify-start gap-3">
+                  <div className="w-8 h-8 rounded-full bg-gray-900 border-2 border-gray-400 flex items-center justify-center flex-shrink-0 mt-1">
+                    <span className="text-white text-xs font-bold">Z</span>
+                  </div>
+                  <div className="bg-white border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-md">
+                    <p className="text-gray-900 text-sm leading-relaxed">
+                      {renderWithPopovers(msg.content, msg.recommendations ?? [], handleViewDetails)}
+                    </p>
+                  </div>
+                </div>
+              ),
+            )}
+
+            {/* 스트리밍 중인 AI 메시지 */}
+            {streaming && (
+              <div className="flex justify-start gap-3">
+                <div className="w-8 h-8 rounded-full bg-gray-900 border-2 border-gray-400 flex items-center justify-center flex-shrink-0 mt-1">
+                  <span className="text-white text-xs font-bold">Z</span>
+                </div>
+                <div className="bg-white border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-md">
+                  <p className="text-gray-900 text-sm leading-relaxed">
+                    {streamContent || (
+                      <span className="inline-flex gap-1">
+                        <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "0ms" }} />
+                        <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "150ms" }} />
+                        <span className="w-1.5 h-1.5 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "300ms" }} />
+                      </span>
+                    )}
+                  </p>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <div className="border-t-2 border-gray-300 p-4">
+            <div className="flex gap-2">
+              <Input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="메시지를 입력하세요..."
+                disabled={streaming}
+                className="flex-1 border-2 border-gray-300 focus:border-gray-900 rounded-lg px-4 py-2"
+              />
+              <Button
+                onClick={handleSend}
+                disabled={streaming || !input.trim()}
+                className="bg-gray-900 text-white hover:bg-gray-800 px-4 disabled:opacity-50"
+              >
+                <Send className="w-5 h-5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* 우측 패널 */}
+        <div className="w-[520px] bg-gray-50 flex flex-col">
+          {/* RAG 출처 */}
+          {ragDocs.length > 0 && (
+            <div className="flex-shrink-0 p-4 border-b-2 border-gray-300">
+              <h3 className="text-lg font-bold text-gray-900 mb-3">참고 출처</h3>
+              <div className="space-y-3">
+                {ragDocs.map((doc, i) => (
+                  <div key={i} className="bg-white border-2 border-gray-300 rounded-lg p-3 hover:border-gray-400 transition-colors">
+                    <p className="text-sm font-medium text-gray-900 mb-1">{doc.title}</p>
+                    <p className="text-xs text-gray-600 mb-1">{doc.source}</p>
+                    {doc.url && <p className="text-xs text-gray-500 font-mono">{doc.url}</p>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* 품종 탭 + CatCard */}
+          {recommendations.length > 0 ? (
+            <>
+              <div className="flex-shrink-0 border-b-2 border-gray-300 bg-white">
+                <div className="flex">
+                  {recommendations.map((breed, i) => (
+                    <button
+                      key={i}
+                      onClick={() => setSelectedBreed(i)}
+                      className={`flex-1 px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                        selectedBreed === i
+                          ? "text-gray-900 border-gray-900"
+                          : "text-gray-500 border-transparent hover:text-gray-700"
+                      }`}
+                    >
+                      {breed.name_ko}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex-1 p-4 overflow-y-auto">
+                <CatCard breed={recommendations[selectedBreed]} />
+              </div>
+            </>
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <p className="text-gray-400 text-sm">품종을 추천받으면 여기에 표시됩니다.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1,159 +1,17 @@
 "use client";
 
-import { useState } from "react";
-import { ArrowLeft, Send } from "lucide-react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Navigation } from "@/components/layout/Navigation";
-import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
-import { BreedPopover } from "@/components/BreedPopover";
-
-interface Message {
-  role: "user" | "ai";
-  content: string;
-}
-
-const initialMessages: Message[] = [
-  {
-    role: "user",
-    content: "처음 고양이를 키우려고 하는데, 온순하고 사람을 잘 따르는 품종을 추천해주세요.",
-  },
-  {
-    role: "ai",
-    content: "처음 고양이를 키우시는 분께는 래그돌을 추천드립니다.",
-  },
-];
 
 export default function ChatPage() {
   const router = useRouter();
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [messages, setMessages] = useState<Message[]>(initialMessages);
-  const [input, setInput] = useState("");
-
-  const handleSend = () => {
-    const text = input.trim();
-    if (!text) return;
-    setMessages((prev) => [...prev, { role: "user", content: text }]);
-    setInput("");
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  };
+  useEffect(() => {
+    router.replace("/chat/new");
+  }, [router]);
 
   return (
-    <div className="h-screen w-full flex flex-col bg-white">
-      <Navigation onMenuClick={() => setDrawerOpen(true)} fullWidth hideNewChat />
-      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
-
-      <div className="flex-1 flex overflow-hidden">
-        {/* Column 1: Chat */}
-        <div className="flex-1 flex flex-col border-r-2 border-gray-300">
-          <div className="h-16 px-4 border-b-2 border-gray-300 flex items-center gap-3">
-            <button
-              onClick={() => router.back()}
-              className="p-2 hover:bg-gray-100 rounded transition-colors"
-            >
-              <ArrowLeft className="w-5 h-5 text-gray-600" />
-            </button>
-            <h2 className="text-lg font-bold text-gray-900">새 대화</h2>
-          </div>
-
-          <div className="flex-1 overflow-y-auto p-4 space-y-4">
-            {messages.map((msg, i) =>
-              msg.role === "user" ? (
-                <div key={i} className="flex justify-end">
-                  <div className="bg-gray-200 border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-md">
-                    <p className="text-gray-900 text-sm leading-relaxed">{msg.content}</p>
-                  </div>
-                </div>
-              ) : (
-                <div key={i} className="flex justify-start gap-3">
-                  <div className="w-8 h-8 rounded-full bg-gray-900 border-2 border-gray-400 flex items-center justify-center flex-shrink-0 mt-1">
-                    <span className="text-white text-xs font-bold">Z</span>
-                  </div>
-                  <div className="bg-white border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-md">
-                    <p className="text-gray-900 text-sm leading-relaxed">{msg.content}</p>
-                  </div>
-                </div>
-              ),
-            )}
-          </div>
-
-          <div className="border-t-2 border-gray-300 p-4">
-            <div className="flex gap-2">
-              <Input
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="메시지를 입력하세요..."
-                className="flex-1 border-2 border-gray-300 focus:border-gray-900 rounded-lg px-4 py-2"
-              />
-              <Button
-                onClick={handleSend}
-                className="bg-gray-900 text-white hover:bg-gray-800 px-4"
-              >
-                <Send className="w-5 h-5" />
-              </Button>
-            </div>
-          </div>
-        </div>
-
-        {/* Column 2: Results Panel */}
-        <div className="w-[520px] bg-gray-50 flex flex-col">
-          <div className="flex-shrink-0 p-4 border-b-2 border-gray-300">
-            <h3 className="text-lg font-bold text-gray-900 mb-3">참고 출처</h3>
-            <div className="space-y-3">
-              {[
-                { title: "래그돌 품종 특성 및 관리 가이드", source: "한국고양이협회", url: "koreacats.or.kr/breeds/ragdoll" },
-                { title: "온순한 고양이 품종 TOP 10", source: "펫케어 매거진", url: "petcare.com/gentle-cat-breeds" },
-                { title: "처음 고양이 입양자를 위한 품종 선택 가이드", source: "동물보호협회", url: "animalcare.org/first-time-cat-owner" },
-              ].map((doc, index) => (
-                <div key={index} className="bg-white border-2 border-gray-300 rounded-lg p-3 hover:border-gray-400 transition-colors">
-                  <p className="text-sm font-medium text-gray-900 mb-1">{doc.title}</p>
-                  <p className="text-xs text-gray-600 mb-1">{doc.source}</p>
-                  <p className="text-xs text-gray-500 font-mono">{doc.url}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex-1 p-4 overflow-y-auto flex items-start justify-center">
-            <div className="w-full max-w-[480px]">
-              <div className="border-2 border-gray-300 bg-white shadow-md rounded-lg overflow-hidden">
-                <div className="w-full h-[360px] bg-gray-200 border-b-2 border-gray-300 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="text-6xl mb-2">🐱</div>
-                    <p className="text-gray-500 font-mono text-xs">BREED IMAGE</p>
-                  </div>
-                </div>
-                <div className="p-5 space-y-3">
-                  <div>
-                    <h3 className="text-xl font-bold text-gray-900">래그돌</h3>
-                    <p className="text-sm text-gray-500 mt-1">Ragdoll</p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {["#온순함", "#실내적응", "#애정많음", "#조용함"].map((tag, i) => (
-                      <span key={i} className="border-2 border-gray-400 text-gray-700 rounded-full px-3 py-1 text-xs">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="h-[2px] bg-gray-300" />
-                  <p className="text-sm text-gray-700 leading-relaxed">
-                    래그돌은 매우 온순하고 사람을 잘 따르는 대형 고양이입니다. 안아주면 인형처럼 축 늘어지는 특성이 있어 래그돌이라는 이름이 붙었습니다.
-                  </p>
-                  <p className="text-xs text-gray-500 pt-1">출처: 한국고양이협회</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+    <div className="h-screen flex items-center justify-center bg-white">
+      <p className="text-gray-400">대화를 준비하는 중...</p>
     </div>
   );
 }

--- a/frontend/src/components/StoreInitializer.tsx
+++ b/frontend/src/components/StoreInitializer.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
+import { useZipsaStore } from "@/store/zipsa";
+import { getZipsaToken } from "@/lib/api";
+
+export function StoreInitializer() {
+  const { status } = useSession();
+  const initialized = useRef(false);
+  const { loadProfile, loadSessions } = useZipsaStore();
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    if (initialized.current) return;
+    initialized.current = true;
+
+    const token = getZipsaToken();
+    if (!token) return;
+
+    loadProfile(token).catch(() => {});
+    loadSessions(token).catch(() => {});
+  }, [status, loadProfile, loadSessions]);
+
+  return null;
+}

--- a/frontend/src/components/chat/CatCard.tsx
+++ b/frontend/src/components/chat/CatCard.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Cat } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Recommendation } from "@/lib/api";
+
+interface CatCardProps {
+  breed: Recommendation;
+}
+
+export function CatCard({ breed }: CatCardProps) {
+  return (
+    <div className="border-2 border-gray-300 bg-white shadow-md rounded-lg overflow-hidden">
+      <div className="w-full h-[360px] bg-gray-200 border-b-2 border-gray-300 overflow-hidden flex items-center justify-center">
+        {breed.image_url ? (
+          <img
+            src={breed.image_url}
+            alt={breed.name_ko}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="text-center">
+            <Cat className="w-16 h-16 text-gray-400 mx-auto mb-2" strokeWidth={1} />
+            <p className="text-gray-400 font-mono text-xs">BREED IMAGE</p>
+          </div>
+        )}
+      </div>
+
+      <div className="p-5 space-y-3">
+        <div>
+          <h3 className="text-xl font-bold text-gray-900">{breed.name_ko}</h3>
+          <p className="text-sm text-gray-500 mt-1">{breed.name_en}</p>
+        </div>
+
+        {breed.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {breed.tags.map((tag, i) => (
+              <Badge
+                key={i}
+                variant="outline"
+                className="border-2 border-gray-400 text-gray-700 rounded-full px-3 py-1 text-xs"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <div className="h-[2px] bg-gray-300" />
+
+        <p className="text-sm text-gray-700 leading-relaxed">{breed.summary}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/GlobalDrawer.tsx
+++ b/frontend/src/components/layout/GlobalDrawer.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { X, Plus, Search, Cat, LogIn, Trash2 } from "lucide-react";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button } from "@/components/ui/button";
+import { getZipsaToken, type ChatSession } from "@/lib/api";
+import { useZipsaStore } from "@/store/zipsa";
 import { Sheet, SheetContent, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -18,22 +20,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { deleteSession } from "@/lib/api";
 
-interface ChatSession {
-  id: string;
-  title: string;
-  date: string;
-}
-
-const mockSessions: ChatSession[] = [
-  { id: "1", title: "아파트에 맞는 고양이 추천", date: "2024.03.01" },
-  { id: "2", title: "래그돌 성격 상담", date: "2024.02.28" },
-  { id: "3", title: "보호소 입양 절차 문의", date: "2024.02.27" },
-  { id: "4", title: "고양이 알레르기 품종", date: "2024.02.25" },
-  { id: "5", title: "브리티시 숏헤어 특징", date: "2024.02.24" },
-  { id: "6", title: "실내 고양이 기르기", date: "2024.02.20" },
-  { id: "7", title: "코리안숏헤어 vs 러시안블루", date: "2024.02.18" },
-];
 
 interface GlobalDrawerProps {
   isOpen: boolean;
@@ -44,6 +32,8 @@ export function GlobalDrawer({ isOpen, onClose }: GlobalDrawerProps) {
   const { status } = useSession();
   const router = useRouter();
   const isLoggedIn = status === "authenticated";
+  const sessions = useZipsaStore((s) => s.sessions);
+  const removeSession = useZipsaStore((s) => s.removeSession);
   const [isDeleting, setIsDeleting] = useState(false);
   const [selectedSession, setSelectedSession] = useState<ChatSession | null>(null);
 
@@ -52,10 +42,17 @@ export function GlobalDrawer({ isOpen, onClose }: GlobalDrawerProps) {
     setIsDeleting(true);
   };
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
+    if (!selectedSession) return;
+    const token = getZipsaToken();
+    if (token) {
+      await deleteSession(token, selectedSession.session_id).catch(() => {});
+      removeSession(selectedSession.session_id);
+    }
     setIsDeleting(false);
-    onClose();
   };
+
+  const visibleSessions = sessions.filter((s) => s.message_count > 0);
 
   const content = isLoggedIn ? (
     <div className="h-full flex flex-col">
@@ -68,7 +65,7 @@ export function GlobalDrawer({ isOpen, onClose }: GlobalDrawerProps) {
         </div>
         <Button
           variant="outline"
-          onClick={() => { router.push("/chat"); onClose(); }}
+          onClick={() => { router.push("/chat/new"); onClose(); }}
           className="w-full border-2 border-gray-900 bg-white text-gray-900 hover:bg-gray-100 gap-2"
         >
           <Plus className="w-4 h-4" />
@@ -96,28 +93,32 @@ export function GlobalDrawer({ isOpen, onClose }: GlobalDrawerProps) {
         </div>
         <ScrollArea className="h-full px-2">
           <div className="space-y-1 pb-4">
-            {mockSessions.map((session) => (
-              <div
-                key={session.id}
-                onClick={() => { router.push(`/chat?session=${session.id}`); onClose(); }}
-                className="w-full h-12 px-3 rounded-lg hover:bg-gray-100 transition-colors flex items-center gap-2 group relative cursor-pointer"
-              >
-                <div className="flex-1 text-left min-w-0">
-                  <p className="text-sm text-gray-900 truncate font-medium">{session.title}</p>
+            {visibleSessions.length === 0 ? (
+              <p className="text-xs text-gray-400 px-3 py-4">대화 기록이 없습니다.</p>
+            ) : (
+              visibleSessions.map((session) => (
+                <div
+                  key={session.session_id}
+                  onClick={() => { router.push(`/chat/${session.session_id}`); onClose(); }}
+                  className="w-full h-12 px-3 rounded-lg hover:bg-gray-100 transition-colors flex items-center gap-2 group relative cursor-pointer"
+                >
+                  <div className="flex-1 text-left min-w-0">
+                    <p className="text-sm text-gray-900 truncate font-medium">{session.title || "새 대화"}</p>
+                  </div>
+                  <div className="flex items-center flex-shrink-0">
+                    <span className="text-xs text-gray-400 whitespace-nowrap group-hover:opacity-0 transition-opacity">
+                      {new Date(session.updated_at).toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" })}
+                    </span>
+                    <button
+                      className="absolute right-3 opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-600"
+                      onClick={(e) => { e.stopPropagation(); handleDelete(session); }}
+                    >
+                      <Trash2 className="w-4 h-4" strokeWidth={2} />
+                    </button>
+                  </div>
                 </div>
-                <div className="flex items-center flex-shrink-0">
-                  <span className="text-xs text-gray-400 whitespace-nowrap group-hover:opacity-0 transition-opacity">
-                    {session.date}
-                  </span>
-                  <button
-                    className="absolute right-3 opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-600"
-                    onClick={(e) => { e.stopPropagation(); handleDelete(session); }}
-                  >
-                    <Trash2 className="w-4 h-4" strokeWidth={2} />
-                  </button>
-                </div>
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </ScrollArea>
       </div>
@@ -133,7 +134,7 @@ export function GlobalDrawer({ isOpen, onClose }: GlobalDrawerProps) {
         </div>
         <Button
           variant="outline"
-          onClick={() => { router.push("/chat"); onClose(); }}
+          onClick={() => { router.push("/chat/new"); onClose(); }}
           className="w-full border-2 border-gray-900 bg-white text-gray-900 hover:bg-gray-100 gap-2"
         >
           <Plus className="w-4 h-4" />

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, User, LogOut, Cat, Menu } from "lucide-react";
@@ -12,7 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { getProfile, getZipsaToken } from "@/lib/api";
+import { useZipsaStore } from "@/store/zipsa";
 
 interface NavigationProps {
   onMenuClick?: () => void;
@@ -24,6 +23,7 @@ export function Navigation({ onMenuClick, fullWidth = false, hideNewChat = false
   const { data: session, status } = useSession();
   const router = useRouter();
   const isLoggedIn = status === "authenticated";
+  const profile = useZipsaStore((s) => s.profile);
 
   // OAuth 기본값
   const rawName = session?.user?.name;
@@ -31,25 +31,9 @@ export function Navigation({ onMenuClick, fullWidth = false, hideNewChat = false
     rawName && rawName !== "undefined" && rawName !== "null" ? rawName : "집사님";
   const oauthAvatar = session?.user?.image ?? null;
 
-  // 프로필에서 불러온 커스텀 값
-  const [profileNickname, setProfileNickname] = useState<string | null>(null);
-  const [profileAvatar, setProfileAvatar] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!isLoggedIn) return;
-    const token = getZipsaToken();
-    if (!token) return;
-    getProfile(token)
-      .then((p) => {
-        if (p.nickname) setProfileNickname(p.nickname);
-        if (p.avatar_url) setProfileAvatar(p.avatar_url);
-      })
-      .catch(() => {/* 프로필 없으면 OAuth 기본값 유지 */});
-  }, [isLoggedIn]);
-
-  // 뱃지에 표시할 값: 프로필 설정값 우선, 없으면 OAuth
-  const badgeAvatar = profileAvatar ?? oauthAvatar;
-  const badgeNickname = profileNickname ?? oauthNickname;
+  // 뱃지: 프로필 설정값 우선, 없으면 OAuth
+  const badgeAvatar = profile?.avatar_url ?? oauthAvatar;
+  const badgeNickname = profile?.nickname ?? oauthNickname;
 
   return (
     <nav className="w-full h-16 border-b-2 border-gray-300 bg-white">
@@ -73,7 +57,7 @@ export function Navigation({ onMenuClick, fullWidth = false, hideNewChat = false
             <>
               {!hideNewChat && (
                 <Button
-                  onClick={() => router.push("/chat")}
+                  onClick={() => router.push("/chat/new")}
                   className="bg-gray-900 hover:bg-gray-800 text-white rounded-full px-6"
                 >
                   새 채팅
@@ -136,7 +120,7 @@ export function Navigation({ onMenuClick, fullWidth = false, hideNewChat = false
             <>
               {!hideNewChat && (
                 <Button
-                  onClick={() => router.push("/chat")}
+                  onClick={() => router.push("/chat/new")}
                   className="bg-gray-900 hover:bg-gray-800 text-white rounded-full px-6"
                 >
                   새 채팅

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { StoreInitializer } from "@/components/StoreInitializer";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <StoreInitializer />
+      {children}
+    </SessionProvider>
+  );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -141,3 +141,109 @@ export async function getAvatarPresignUrl(
   if (!res.ok) throw new Error(`getAvatarPresignUrl failed: ${res.status}`);
   return res.json();
 }
+
+// ── Chat ─────────────────────────────────────────────────────────────────────
+
+export interface Recommendation {
+  name_ko: string;
+  name_en: string;
+  image_url: string;
+  summary: string;
+  tags: string[];
+  stats: Record<string, number>;
+}
+
+export interface RagDoc {
+  title: string;
+  subtitle: string;
+  source: string;
+  url: string;
+}
+
+export interface ChatSession {
+  session_id: string;
+  user_id: string;
+  thread_id: string;
+  title: string;
+  last_message: string | null;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChatMessage {
+  message_id: string;
+  session_id: string;
+  role: "human" | "ai";
+  content: string;
+  recommendations: Recommendation[];
+  rag_docs: RagDoc[];
+  created_at: string;
+}
+
+export async function createSession(token: string): Promise<ChatSession> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) throw new Error(`createSession failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getSessions(token: string): Promise<ChatSession[]> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/sessions`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getSessions failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteSession(token: string, sessionId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/sessions/${sessionId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`deleteSession failed: ${res.status}`);
+}
+
+export async function getMessages(token: string, sessionId: string): Promise<ChatMessage[]> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/sessions/${sessionId}/messages`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getMessages failed: ${res.status}`);
+  return res.json();
+}
+
+export async function* streamChat(
+  token: string,
+  sessionId: string,
+  message: string,
+  userProfile?: UserProfileResponse | null,
+): AsyncGenerator<{ type: string; content?: string; data?: unknown }> {
+  const res = await fetch(`${API_BASE}/api/v1/chat/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ session_id: sessionId, message, user_profile: userProfile ?? null }),
+  });
+  if (!res.ok) throw new Error(`streamChat failed: ${res.status}`);
+  if (!res.body) return;
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const payload = line.slice(6);
+      if (payload === "[DONE]") return;
+      try { yield JSON.parse(payload); } catch { /* skip malformed */ }
+    }
+  }
+}

--- a/frontend/src/store/zipsa.ts
+++ b/frontend/src/store/zipsa.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { getProfile, getSessions, type UserProfileResponse, type ChatSession } from "@/lib/api";
+
+interface ZipsaState {
+  profile: UserProfileResponse | null;
+  sessions: ChatSession[];
+
+  setProfile: (profile: UserProfileResponse | null) => void;
+  setSessions: (sessions: ChatSession[]) => void;
+  addSession: (session: ChatSession) => void;
+  removeSession: (sessionId: string) => void;
+  updateSession: (sessionId: string, updates: Partial<ChatSession>) => void;
+
+  loadProfile: (token: string) => Promise<void>;
+  loadSessions: (token: string) => Promise<void>;
+}
+
+export const useZipsaStore = create<ZipsaState>((set) => ({
+  profile: null,
+  sessions: [],
+
+  setProfile: (profile) => set({ profile }),
+  setSessions: (sessions) => set({ sessions }),
+
+  addSession: (session) =>
+    set((state) => ({ sessions: [session, ...state.sessions] })),
+
+  removeSession: (sessionId) =>
+    set((state) => ({
+      sessions: state.sessions.filter((s) => s.session_id !== sessionId),
+    })),
+
+  updateSession: (sessionId, updates) =>
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.session_id === sessionId ? { ...s, ...updates } : s,
+      ),
+    })),
+
+  loadProfile: async (token) => {
+    const profile = await getProfile(token);
+    set({ profile });
+  },
+
+  loadSessions: async (token) => {
+    const sessions = await getSessions(token);
+    set({ sessions });
+  },
+}));

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -116,7 +116,7 @@ async def stream_chat(
             async for event in graph_app.astream_events(
                 {
                     "messages": [HumanMessage(content=body.message)],
-                    "user_profile": {},
+                    "user_profile": body.user_profile or {},
                 },
                 config={"configurable": {"thread_id": thread_id}},
                 version="v2",

--- a/src/core/models/chat.py
+++ b/src/core/models/chat.py
@@ -57,6 +57,7 @@ class ChatMessageResponse(BaseModel):
 class ChatInvokeRequest(BaseModel):
     session_id: str
     message: str
+    user_profile: Optional[Dict[str, Any]] = Field(default=None, description="프론트에서 전달하는 온보딩 프로파일")
 
 
 class ChatInvokeResponse(BaseModel):


### PR DESCRIPTION
## 개요

채팅 API 연동 및 Zustand 기반 전역 상태 관리를 구현합니다.

## 변경 사항

### 채팅 페이지 구현 (closes #66, closes #34)
- `/chat/new` — lazy session creation: 첫 메시지 전송 시 세션 생성 (사전 생성 없음)
- `/chat/[id]` — SSE 스트리밍, BreedPopover 인라인 렌더링, CatCard 우측 패널, RAG 출처 패널
- `CatCard` 컴포넌트: 품종 이미지/태그/설명 카드
- `api.ts`: `createSession`, `getSessions`, `deleteSession`, `getMessages`, `streamChat` 추가
- `ChatInvokeRequest`에 `user_profile` 필드 추가, 백엔드 하드코딩(`{}`) 제거
- `sendingRef` / `loadedSessionRef`로 StrictMode 이중 실행 방지

### Zustand 전역 상태 관리 (closes #67)
- `useZipsaStore`: `profile`, `sessions` 전역 상태 + `addSession`, `removeSession`, `updateSession`
- `StoreInitializer`: 로그인 시 1회 `loadProfile` + `loadSessions`
- `Navigation`: store `profile` 구독, 직접 fetch 제거
- `GlobalDrawer`: store `sessions` 구독, 드로어 열 때마다 fetch 제거
- 채팅 페이지: 세션 생성·완료 시 store 업데이트, `user_profile`을 `streamChat`에 전달

## 테스트

- [x] 새 채팅 → 메시지 전송 시 세션 생성 확인 (사전 생성 없음)
- [x] 채팅 스트리밍 정상 동작 확인
- [x] GlobalDrawer 세션 목록 표시 및 삭제
- [x] Navigation 프로필 뱃지 (store 기반)