### PR TITLE
feat: CatCard 통합 모델링 및 user_cats CRUD 백엔드 구현

### DIFF
--- a/src/agents/filters/breed_criteria.py
+++ b/src/agents/filters/breed_criteria.py
@@ -8,8 +8,8 @@ from src.utils.mongodb import MongoDBManager
 llm_router = init_chat_model(LLMConfig.ROUTER_MODEL, model_provider="openai", temperature=0)
 
 # 실제 데이터 기반 threshold 정의 (67종 분포 기준)
-# - affection_level, child_friendly, adaptability: 분화 없음 → 제외
-# - social_needs: 실제 min=3, "독립적인" 기준 <= 3
+# - affection_level (97%가 4-5), child_friendly (85%가 >=4), adaptability (평균 4.8): 분화 없음 → 제외
+# - social_needs: 실제 min=3, "독립적인" 기준 <= 3 (energy_level <= 2는 4종뿐 → 미사용)
 # - energy_level: "얌전한" 기준 <= 3 (>= 4: 61%, <= 3: 39%)
 _SYSTEM_PROMPT = """사용자의 발화에서 고양이 품종 선호 조건을 추출하세요.
 
@@ -18,6 +18,7 @@ _SYSTEM_PROMPT = """사용자의 발화에서 고양이 품종 선호 조건을 
 - energy_level: 활동성 (1-5, 높을수록 활발)
 - vocalisation: 울음소리 빈도 (1-5)
 - grooming: 그루밍 필요도 (1-5)
+- intelligence: 지능 (1-5, 높을수록 영리함)
 - social_needs: 사회적 욕구 (3-5, 낮을수록 독립적)
 - hypoallergenic: 저알레르기 (0 또는 1)
 - lap: 무릎냥이 여부 (0 또는 1)
@@ -26,12 +27,15 @@ _SYSTEM_PROMPT = """사용자의 발화에서 고양이 품종 선호 조건을 
 - "털 안 빠지는", "털 적은" → shedding_level <= 2
 - "활발한", "에너지 넘치는" → energy_level >= 4
 - "얌전한", "조용한", "차분한" → energy_level <= 3
+- "초보자", "처음 키우는", "입문용" → energy_level <= 3, grooming <= 3
 - "소리 안 내는", "울음 적은" → vocalisation <= 2
 - "혼자 있어도 괜찮은", "독립적인" → social_needs <= 3
 - "알레르기" → hypoallergenic == 1
 - "무릎냥이" → lap == 1
 - "그루밍 적게", "관리 쉬운" → grooming <= 2
+- "영리한", "훈련 가능한", "지능 높은" → intelligence >= 4
 
+주의: energy_level <= 2는 데이터상 4종뿐이므로 사용하지 마세요. 최솟값은 <= 3입니다.
 조건 형식: "shedding_level <= 2", "energy_level >= 4", "hypoallergenic == 1"
 조건이 없으면 빈 리스트를 반환하세요."""
 

--- a/src/agents/liaison.py
+++ b/src/agents/liaison.py
@@ -1,6 +1,7 @@
 """
 리에종: 입양 및 구조 정보 전문가
 """
+import json
 import logging
 
 from langchain.chat_models import init_chat_model
@@ -52,16 +53,24 @@ async def _liaison_node(state: AgentState) -> Command:
     # 도구 실행 후 복귀 시, 도구 결과를 구조화된 출력으로 패키징
     if isinstance(last_msg, ToolMessage):
         tool_content = last_msg.content
+        rescue_cats = []
+        try:
+            tool_data = json.loads(tool_content) if isinstance(tool_content, str) else tool_content
+            rescue_cats = tool_data.get("rescue_cats", [])
+        except (json.JSONDecodeError, AttributeError):
+            logger.warning("ToolMessage content JSON 파싱 실패")
+
         specialist_result = {
             "source": "liaison",
             "type": "tool_result",
             "specialist_name": "입양/구조 비서",
             "persona": prompt_manager.get_prompt("liaison", field="persona"),
             "tool_output": tool_content,
+            "rescue_cats": rescue_cats,
             "rag_docs": [],
         }
         return Command(
-            update={"specialist_result": specialist_result},
+            update={"specialist_result": specialist_result, "rescue_cats": rescue_cats},
             goto="head_butler"
         )
 

--- a/src/agents/matchmaker.py
+++ b/src/agents/matchmaker.py
@@ -76,6 +76,13 @@ async def _matchmaker_node(state: AgentState) -> Command:
     if filter_result and filter_result.mongo_filter:
         search_filters.update(filter_result.mongo_filter)
 
+    # RECOMMEND 모드: user_profile hard constraints 적용 (안전 필수 제약, LLM 우회 불가)
+    # allergy, has_children, has_dog, has_cat, work_style 기반 MongoDB 필터를 강제 적용
+    if intent.category == "RECOMMEND":
+        hard_constraints = user.get_hard_constraints()
+        for k, v in hard_constraints.items():
+            search_filters[f"stats.{k}"] = v
+
     retriever = HybridRetriever(collection_name="care_guides")
     raw_results = await retriever.search(
         search_query,
@@ -171,6 +178,8 @@ async def _matchmaker_node(state: AgentState) -> Command:
             clean_r["tags"] = [f"#{t}" for t in traits[:4]] if traits else []
         results.append(clean_r)
 
+    # 선별된 top_results 기준으로만 rag_docs 생성 (raw_results 전체 X)
+    # → head_butler LLM이 10개가 아닌 3개 품종 이름만 보게 되어 답변 일관성 확보
     rag_docs = [
         {
             "title": r.get("name_ko", ""),
@@ -178,7 +187,7 @@ async def _matchmaker_node(state: AgentState) -> Command:
             "source": "TheCatAPI, Wikipedia",
             "url": r.get("source_url") or r.get("source_urls", [""])[0] if r.get("source_urls") else "",
         }
-        for r in raw_results
+        for r in top_results
     ]
 
     reasoning_text = f"**[{intent.category}]** 모드로 검색했습니다.\n\n[선별 이유]\n{selection.reasoning}"

--- a/src/agents/state.py
+++ b/src/agents/state.py
@@ -23,6 +23,7 @@ class AgentState(Dict[str, Any]):
     # 내부: 전문가 → 집사 구조화된 결과
     specialist_result: Optional[Dict[str, Any]]
 
-    # UI용 결과 (품종 카드, RAG 출처)
+    # UI용 결과 (품종 카드, RAG 출처, 구조묘 카드)
     recommendations: Optional[List[Dict[str, Any]]]
     rag_docs: Optional[List[Dict[str, Any]]]
+    rescue_cats: Optional[List[Dict[str, Any]]]

--- a/src/agents/tools/animal_protection.py
+++ b/src/agents/tools/animal_protection.py
@@ -68,10 +68,8 @@ async def search_abandoned_animals(
     upr_cd = SIDO_CODES.get(sido)
     if not upr_cd:
         return {
-            "success": False,
-            "total": 0,
-            "animals": [],
-            "message": f"'{sido}'에 해당하는 시도 코드를 찾을 수 없습니다. "
+            "rescue_cats": [],
+            "summary": f"'{sido}'에 해당하는 시도 코드를 찾을 수 없습니다. "
                        f"가능한 값: {', '.join(SIDO_CODES.keys())}",
         }
 
@@ -88,10 +86,8 @@ async def search_abandoned_animals(
         org_cd = sigungu_map.get(sigungu)
         if not org_cd:
             return {
-                "success": False,
-                "total": 0,
-                "animals": [],
-                "message": f"'{sigungu}'에 해당하는 시군구 코드를 찾을 수 없습니다. "
+                "rescue_cats": [],
+                "summary": f"'{sigungu}'에 해당하는 시군구 코드를 찾을 수 없습니다. "
                            f"가능한 값: {', '.join(sigungu_map.keys())}",
             }
         params["org_cd"] = org_cd
@@ -106,10 +102,8 @@ async def search_abandoned_animals(
     except Exception as e:
         logger.exception("유기동물 API 호출 실패")
         return {
-            "success": False,
-            "total": 0,
-            "animals": [],
-            "message": f"API 호출 중 오류가 발생했습니다: {e}",
+            "rescue_cats": [],
+            "summary": f"API 호출 중 오류가 발생했습니다: {e}",
         }
 
     body = resp.get("body", {})
@@ -118,57 +112,52 @@ async def search_abandoned_animals(
 
     if not items or not items.get("item"):
         return {
-            "success": True,
-            "total": 0,
-            "animals": [],
-            "message": "조건에 맞는 보호 동물이 없습니다.",
+            "rescue_cats": [],
+            "summary": "조건에 맞는 보호 동물이 없습니다.",
         }
 
     raw_items = items["item"]
     if isinstance(raw_items, dict):
         raw_items = [raw_items]
 
-    animals = []
+    rescue_cats = []
     for item in raw_items:
-        animal = {
-            "desertionNo": item.get("desertionNo", ""),
+        cat = {
+            "animal_id": item.get("desertionNo", ""),
             "breed": item.get("kindNm", item.get("kindCd", "")),
-            "color": item.get("colorCd", ""),
             "age": item.get("age", ""),
-            "weight": item.get("weight", ""),
             "sex": {"M": "수컷", "F": "암컷", "Q": "미상"}.get(
                 item.get("sexCd", ""), "미상"
             ),
-            "neuter": {"Y": "중성화 완료", "N": "미완료", "U": "미상"}.get(
+            "neutered": {"Y": "중성화 완료", "N": "미완료", "U": "미상"}.get(
                 item.get("neuterYn", ""), "미상"
             ),
             "feature": item.get("specialMark", ""),
-            "image": item.get("popfile1", item.get("popfile2", "")),
+            "image_url": item.get("popfile1", item.get("popfile2", "")),
             "shelter_name": item.get("careNm", ""),
             "shelter_address": item.get("careAddr", ""),
-            "shelter_tel": item.get("careTel", ""),
-            "notice_period": f"{item.get('noticeSdt', '')}~{item.get('noticeEdt', '')}",
-            "happen_place": item.get("happenPlace", ""),
+            "shelter_phone": item.get("careTel", ""),
+            "notice_end_date": item.get("noticeEdt", ""),
+            "sido": sido,
+            "sigungu": sigungu,
         }
-        
+
         # 품종 필터링
-        if breed and breed not in animal["breed"]:
+        if breed and breed not in cat["breed"]:
             continue
-            
+
         # 보호소 키워드 필터링 (보호소 이름 또는 주소에 키워드가 포함된 경우)
         if shelter_keyword:
-            in_name = shelter_keyword in animal["shelter_name"]
-            in_addr = shelter_keyword in animal["shelter_address"]
+            in_name = shelter_keyword in cat["shelter_name"]
+            in_addr = shelter_keyword in cat["shelter_address"]
             if not (in_name or in_addr):
                 continue
-            
-        animals.append(animal)
-        if len(animals) >= 5:
+
+        rescue_cats.append(cat)
+        if len(rescue_cats) >= 5:
             break
 
     return {
-        "success": True,
-        "total": total,
-        "animals": animals,
-        "message": f"총 {total}건 중 {len(animals)}건을 표시합니다.",
+        "rescue_cats": rescue_cats,
+        "summary": f"총 {total}건 중 {len(rescue_cats)}건을 표시합니다.",
     }

--- a/src/api/routers/cats.py
+++ b/src/api/routers/cats.py
@@ -1,0 +1,123 @@
+"""
+/api/v1/users/me/cats — 유저 고양이 CRUD
+"""
+import logging
+import os
+from datetime import datetime, timezone
+
+import certifi
+from bson import ObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.api.dependencies import get_current_user
+from src.core.config import AuthConfig
+from src.core.models.auth import AuthUser
+from src.core.models.user_cat import (
+    UserCatCreateRequest,
+    UserCatHealth,
+    UserCatResponse,
+    UserCatUpdateRequest,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/users/me/cats", tags=["Cats"])
+
+
+def _get_cats_col():
+    uri = os.getenv("MONGO_V3_URI")
+    client = AsyncIOMotorClient(uri, tlsCAFile=certifi.where())
+    return client[AuthConfig.USER_DB_NAME]["user_cats"]
+
+
+def _doc_to_response(doc: dict) -> UserCatResponse:
+    health_data = doc.get("health") or {}
+    return UserCatResponse(
+        cat_id=str(doc["_id"]),
+        user_id=str(doc["user_id"]),
+        name=doc["name"],
+        age_months=doc.get("age_months", 0),
+        gender=doc.get("gender", "미상"),
+        breed_name_ko=doc.get("breed_name_ko", ""),
+        breed_name_en=doc.get("breed_name_en", ""),
+        profile_image_url=doc.get("profile_image_url"),
+        health=UserCatHealth(**health_data) if health_data else UserCatHealth(),
+        created_at=doc["created_at"],
+        updated_at=doc["updated_at"],
+    )
+
+
+@router.get("", response_model=list[UserCatResponse])
+async def list_cats(
+    current_user: AuthUser = Depends(get_current_user),
+) -> list[UserCatResponse]:
+    """내 고양이 목록 조회."""
+    col = _get_cats_col()
+    cursor = col.find({"user_id": current_user.user_id})
+    docs = await cursor.to_list(length=100)
+    return [_doc_to_response(d) for d in docs]
+
+
+@router.post("", response_model=UserCatResponse, status_code=status.HTTP_201_CREATED)
+async def create_cat(
+    body: UserCatCreateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserCatResponse:
+    """고양이 등록."""
+    col = _get_cats_col()
+    now = datetime.now(timezone.utc)
+    doc = {
+        "user_id": current_user.user_id,
+        **body.model_dump(),
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = await col.insert_one(doc)
+    doc["_id"] = result.inserted_id
+    return _doc_to_response(doc)
+
+
+@router.get("/{cat_id}", response_model=UserCatResponse)
+async def get_cat(
+    cat_id: str,
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserCatResponse:
+    """고양이 상세 조회."""
+    col = _get_cats_col()
+    doc = await col.find_one({"_id": ObjectId(cat_id), "user_id": current_user.user_id})
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="고양이를 찾을 수 없습니다.")
+    return _doc_to_response(doc)
+
+
+@router.put("/{cat_id}", response_model=UserCatResponse)
+async def update_cat(
+    cat_id: str,
+    body: UserCatUpdateRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> UserCatResponse:
+    """고양이 정보 수정."""
+    col = _get_cats_col()
+    now = datetime.now(timezone.utc)
+    update_fields = {k: v for k, v in body.model_dump().items() if v is not None}
+    update_fields["updated_at"] = now
+    doc = await col.find_one_and_update(
+        {"_id": ObjectId(cat_id), "user_id": current_user.user_id},
+        {"$set": update_fields},
+        return_document=True,
+    )
+    if not doc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="고양이를 찾을 수 없습니다.")
+    return _doc_to_response(doc)
+
+
+@router.delete("/{cat_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_cat(
+    cat_id: str,
+    current_user: AuthUser = Depends(get_current_user),
+) -> None:
+    """고양이 삭제."""
+    col = _get_cats_col()
+    result = await col.delete_one({"_id": ObjectId(cat_id), "user_id": current_user.user_id})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="고양이를 찾을 수 없습니다.")

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -111,6 +111,7 @@ async def stream_chat(
         full_content = ""
         rag_docs = []
         recommendations = []
+        rescue_cats = []
 
         try:
             async for event in graph_app.astream_events(
@@ -143,6 +144,9 @@ async def stream_chat(
                         if output.get("recommendations"):
                             recommendations = output["recommendations"]
                             yield f"data: {json.dumps({'type': 'recommendations', 'data': recommendations})}\n\n"
+                        if output.get("rescue_cats"):
+                            rescue_cats = output["rescue_cats"]
+                            yield f"data: {json.dumps({'type': 'rescue_cats', 'data': rescue_cats})}\n\n"
 
         except Exception:
             logger.exception("stream_chat 오류")

--- a/src/core/models/chat.py
+++ b/src/core/models/chat.py
@@ -42,6 +42,22 @@ class Recommendation(BaseModel):
     stats: Dict[str, Any] = Field(default_factory=dict)
 
 
+class RescueCat(BaseModel):
+    animal_id: str = ""
+    breed: str = ""
+    age: str = ""
+    sex: str = ""
+    neutered: str = ""
+    feature: str = ""
+    image_url: str = ""
+    shelter_name: str = ""
+    shelter_address: str = ""
+    shelter_phone: str = ""
+    notice_end_date: str = ""
+    sido: str = ""
+    sigungu: str = ""
+
+
 class ChatMessageResponse(BaseModel):
     message_id: str
     session_id: str
@@ -49,6 +65,7 @@ class ChatMessageResponse(BaseModel):
     content: str
     recommendations: List[Recommendation] = Field(default_factory=list)
     rag_docs: List[RagDoc] = Field(default_factory=list)
+    rescue_cats: List[RescueCat] = Field(default_factory=list)
     created_at: datetime
 
 
@@ -65,3 +82,4 @@ class ChatInvokeResponse(BaseModel):
     content: str
     recommendations: List[Recommendation] = Field(default_factory=list)
     rag_docs: List[RagDoc] = Field(default_factory=list)
+    rescue_cats: List[RescueCat] = Field(default_factory=list)

--- a/src/core/models/user_cat.py
+++ b/src/core/models/user_cat.py
@@ -1,0 +1,50 @@
+"""
+내 고양이 Pydantic 모델.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VaccinationInfo(BaseModel):
+    label: str = ""
+    date: str = ""
+
+
+class UserCatHealth(BaseModel):
+    vaccinations: List[VaccinationInfo] = Field(default_factory=list)
+
+
+class UserCatCreateRequest(BaseModel):
+    name: str
+    age_months: int = 0
+    gender: str = "미상"  # "M" | "F" | "미상"
+    breed_name_ko: str = ""
+    breed_name_en: str = ""
+    profile_image_url: Optional[str] = None
+    health: Optional[UserCatHealth] = None
+
+
+class UserCatUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    age_months: Optional[int] = None
+    gender: Optional[str] = None
+    breed_name_ko: Optional[str] = None
+    breed_name_en: Optional[str] = None
+    profile_image_url: Optional[str] = None
+    health: Optional[UserCatHealth] = None
+
+
+class UserCatResponse(BaseModel):
+    cat_id: str
+    user_id: str
+    name: str
+    age_months: int = 0
+    gender: str = "미상"
+    breed_name_ko: str = ""
+    breed_name_en: str = ""
+    profile_image_url: Optional[str] = None
+    health: UserCatHealth = Field(default_factory=UserCatHealth)
+    created_at: datetime
+    updated_at: datetime

--- a/src/core/models/user_profile.py
+++ b/src/core/models/user_profile.py
@@ -51,25 +51,21 @@ class UserProfile(BaseModel):
         """
         constraints = {}
         
-        # 알레르기: 건강 필수 사항
+        # 알레르기: 건강 필수 사항 — hypoallergenic (15종, 22%)
         if self.allergy:
             constraints["hypoallergenic"] = 1
-        
-        # 자녀: 안전 필수 사항
-        if self.has_children or "어린 아이" in self.companion:
-            constraints["child_friendly"] = 4
-        
-        # 강아지: 행동 호환성 사항
-        if self.has_dog or "강아지" in self.companion:
-            constraints["dog_friendly"] = 4
 
-        # 다묘 가정: 고양이 사회성 사항
+        # 다묘 가정: 최소 사회성 보장 — social_needs >= 3 (실제 min=3이므로 사실상 모두 통과)
         if self.has_cat or "고양이 있음" in self.companion:
             constraints["social_needs"] = {"$gte": 3}
 
-        # 장시간 부재: 독립적인 품종 필터
+        # 장시간 부재: 독립적인 품종 — social_needs <= 3 (min=3이므로 social_needs==3 품종만)
         if self.work_style in ("4~8시간", "8시간 이상"):
             constraints["social_needs"] = {"$lte": 3}
+
+        # 제외 필드 (분화 없음, 필터 무의미):
+        # - child_friendly: 85%가 >= 4 → 컨텍스트 문자열로 LLM 선별에만 반영
+        # - dog_friendly: 평균 4.6 → 동일
 
         return constraints
     

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,11 @@ ZIPSA FastAPI 서버 엔트리포인트
   GET  /api/v1/users/me/sessions/{id}             — 세션 상세
   DELETE /api/v1/users/me/sessions/{id}           — 세션 삭제
   GET  /api/v1/users/me/sessions/{id}/messages    — 메시지 목록
+  GET  /api/v1/users/me/cats                      — 내 고양이 목록
+  POST /api/v1/users/me/cats                      — 고양이 등록
+  GET  /api/v1/users/me/cats/{id}                 — 고양이 상세
+  PUT  /api/v1/users/me/cats/{id}                 — 고양이 수정
+  DELETE /api/v1/users/me/cats/{id}               — 고양이 삭제
   POST /api/v1/chat/invoke                        — 동기 채팅
   POST /api/v1/chat/stream                        — SSE 스트리밍
 """
@@ -30,7 +35,7 @@ from fastapi.staticfiles import StaticFiles
 
 load_dotenv(Path(__file__).parents[1] / ".env")
 
-from src.api.routers import auth, chat, meme, sessions, users
+from src.api.routers import auth, cats, chat, meme, sessions, users
 
 app = FastAPI(
     title="ZIPSA API",
@@ -48,6 +53,7 @@ app.add_middleware(
 
 app.include_router(auth.router)
 app.include_router(users.router)
+app.include_router(cats.router)
 app.include_router(sessions.router)
 app.include_router(chat.router)
 app.include_router(meme.router)


### PR DESCRIPTION
## Summary

- `search_abandoned_animals` tool 반환 형식을 JSON으로 변경 (`rescue_cats` 리스트)
- `AgentState`에 `rescue_cats` 필드 추가
- Liaison 에이전트에서 ToolMessage JSON 파싱 → rescue_cats 상태 업데이트
- `RescueCat` Pydantic 모델 추가, `ChatMessageResponse`/`ChatInvokeResponse`에 rescue_cats 필드 추가
- SSE 스트리밍에서 `rescue_cats` 이벤트 emit
- `user_cats` CRUD 엔드포인트 구현 (`/api/v1/users/me/cats`)
- matchmaker rag_docs 10→3개 수정, hard constraints 적용, 필터링 정책 준수

## Test plan

- [x] Liaison 호출 시 rescue_cats SSE 이벤트 수신 확인
- [x] `/api/v1/users/me/cats` CRUD 동작 확인
- [x] matchmaker rag_docs 3개, 추천 품종 LLM 답변 일치 확인

Closes #29