### PR TITLE
feat: RescueCatCard/UserCatCard 컴포넌트, my-cats 페이지 구현

### DIFF
--- a/frontend/src/app/chat/[id]/page.tsx
+++ b/frontend/src/app/chat/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Navigation } from "@/components/layout/Navigation";
 import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
 import { BreedPopover } from "@/components/BreedPopover";
 import { CatCard } from "@/components/chat/CatCard";
+import { RescueCatCard } from "@/components/chat/RescueCatCard";
 import {
   getZipsaToken,
   createSession,
@@ -17,6 +18,7 @@ import {
   type ChatMessage,
   type Recommendation,
   type RagDoc,
+  type RescueCat,
 } from "@/lib/api";
 import { useZipsaStore } from "@/store/zipsa";
 
@@ -74,7 +76,11 @@ export default function ChatSessionPage() {
   const [streamContent, setStreamContent] = useState("");
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [ragDocs, setRagDocs] = useState<RagDoc[]>([]);
+  const [rescueCats, setRescueCats] = useState<RescueCat[]>([]);
   const [selectedBreed, setSelectedBreed] = useState(0);
+  const [selectedRescue, setSelectedRescue] = useState(0);
+  // 0 = breed panel, 1 = rescue panel
+  const [panelMode, setPanelMode] = useState<"breed" | "rescue">("breed");
   const [sessionTitle, setSessionTitle] = useState("새 대화");
   const [creating, setCreating] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -93,8 +99,15 @@ export default function ChatSessionPage() {
         setMessages(msgs);
         const lastAI = [...msgs].reverse().find((m) => m.role === "ai");
         if (lastAI) {
-          if (lastAI.recommendations?.length) setRecommendations(lastAI.recommendations);
+          if (lastAI.recommendations?.length) {
+            setRecommendations(lastAI.recommendations);
+            setPanelMode("breed");
+          }
           if (lastAI.rag_docs?.length) setRagDocs(lastAI.rag_docs);
+          if (lastAI.rescue_cats?.length) {
+            setRescueCats(lastAI.rescue_cats);
+            setPanelMode("rescue");
+          }
         }
         const firstHuman = msgs.find((m) => m.role === "human");
         if (firstHuman) setSessionTitle(firstHuman.content.slice(0, 30));
@@ -143,6 +156,7 @@ export default function ChatSessionPage() {
       content: text,
       recommendations: [],
       rag_docs: [],
+      rescue_cats: [],
       created_at: new Date().toISOString(),
     };
     setMessages((prev) => [...prev, userMsg]);
@@ -152,6 +166,7 @@ export default function ChatSessionPage() {
     let fullContent = "";
     let newRecs: Recommendation[] = [];
     let newDocs: RagDoc[] = [];
+    let newRescueCats: RescueCat[] = [];
 
     try {
       for await (const event of streamChat(token, activeSessionId, text, profile)) {
@@ -162,9 +177,15 @@ export default function ChatSessionPage() {
           newRecs = event.data as Recommendation[];
           setRecommendations(newRecs);
           setSelectedBreed(0);
+          setPanelMode("breed");
         } else if (event.type === "rag_docs" && Array.isArray(event.data)) {
           newDocs = event.data as RagDoc[];
           setRagDocs(newDocs);
+        } else if (event.type === "rescue_cats" && Array.isArray(event.data)) {
+          newRescueCats = event.data as RescueCat[];
+          setRescueCats(newRescueCats);
+          setSelectedRescue(0);
+          setPanelMode("rescue");
         }
       }
     } catch (err) {
@@ -177,6 +198,7 @@ export default function ChatSessionPage() {
         content: fullContent,
         recommendations: newRecs,
         rag_docs: newDocs,
+        rescue_cats: newRescueCats,
         created_at: new Date().toISOString(),
       };
       setMessages((prev) => [...prev, aiMsg]);
@@ -309,8 +331,36 @@ export default function ChatSessionPage() {
             </div>
           )}
 
+          {/* 패널 모드 전환 탭 (둘 다 있을 때만) */}
+          {recommendations.length > 0 && rescueCats.length > 0 && (
+            <div className="flex-shrink-0 border-b-2 border-gray-300 bg-white">
+              <div className="flex">
+                <button
+                  onClick={() => setPanelMode("breed")}
+                  className={`flex-1 px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                    panelMode === "breed"
+                      ? "text-gray-900 border-gray-900"
+                      : "text-gray-500 border-transparent hover:text-gray-700"
+                  }`}
+                >
+                  추천 품종
+                </button>
+                <button
+                  onClick={() => setPanelMode("rescue")}
+                  className={`flex-1 px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                    panelMode === "rescue"
+                      ? "text-gray-900 border-gray-900"
+                      : "text-gray-500 border-transparent hover:text-gray-700"
+                  }`}
+                >
+                  구조묘 ({rescueCats.length})
+                </button>
+              </div>
+            </div>
+          )}
+
           {/* 품종 탭 + CatCard */}
-          {recommendations.length > 0 ? (
+          {panelMode === "breed" && recommendations.length > 0 ? (
             <>
               <div className="flex-shrink-0 border-b-2 border-gray-300 bg-white">
                 <div className="flex">
@@ -331,6 +381,29 @@ export default function ChatSessionPage() {
               </div>
               <div className="flex-1 p-4 overflow-y-auto">
                 <CatCard breed={recommendations[selectedBreed]} />
+              </div>
+            </>
+          ) : panelMode === "rescue" && rescueCats.length > 0 ? (
+            <>
+              <div className="flex-shrink-0 border-b-2 border-gray-300 bg-white">
+                <div className="flex overflow-x-auto">
+                  {rescueCats.map((cat, i) => (
+                    <button
+                      key={i}
+                      onClick={() => setSelectedRescue(i)}
+                      className={`flex-shrink-0 px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                        selectedRescue === i
+                          ? "text-gray-900 border-gray-900"
+                          : "text-gray-500 border-transparent hover:text-gray-700"
+                      }`}
+                    >
+                      {cat.breed || `#${i + 1}`}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex-1 p-4 overflow-y-auto">
+                <RescueCatCard cat={rescueCats[selectedRescue]} />
               </div>
             </>
           ) : (

--- a/frontend/src/app/my-cats/[id]/page.tsx
+++ b/frontend/src/app/my-cats/[id]/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Navigation } from "@/components/layout/Navigation";
+import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { getZipsaToken, getUserCats, updateUserCat, deleteUserCat, type UserCat } from "@/lib/api";
+
+export default function EditCatPage() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [cat, setCat] = useState<UserCat | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    breed_name_ko: "",
+    breed_name_en: "",
+    age_months: "",
+    gender: "미상",
+    profile_image_url: "",
+  });
+
+  useEffect(() => {
+    const token = getZipsaToken();
+    if (!token) return;
+    getUserCats(token)
+      .then((cats) => {
+        const found = cats.find((c) => c.cat_id === id);
+        if (found) {
+          setCat(found);
+          setForm({
+            name: found.name,
+            breed_name_ko: found.breed_name_ko,
+            breed_name_en: found.breed_name_en,
+            age_months: String(found.age_months),
+            gender: found.gender,
+            profile_image_url: found.profile_image_url ?? "",
+          });
+        }
+      })
+      .catch(() => {});
+  }, [id]);
+
+  const set = (key: keyof typeof form, value: string) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim() || !cat) return;
+    const token = getZipsaToken();
+    if (!token) return;
+    setSubmitting(true);
+    try {
+      await updateUserCat(token, cat.cat_id, {
+        name: form.name.trim(),
+        breed_name_ko: form.breed_name_ko.trim(),
+        breed_name_en: form.breed_name_en.trim(),
+        age_months: form.age_months ? parseInt(form.age_months, 10) : 0,
+        gender: form.gender,
+        profile_image_url: form.profile_image_url.trim() || null,
+      });
+      router.push("/my-cats");
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const token = getZipsaToken();
+    if (!token || !cat) return;
+    try {
+      await deleteUserCat(token, cat.cat_id);
+      router.push("/my-cats");
+    } catch { /* ignore */ }
+  };
+
+  if (!cat) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <span className="text-gray-400 text-sm">불러오는 중...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation onMenuClick={() => setDrawerOpen(true)} />
+      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      <div className="max-w-[480px] mx-auto px-6 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => router.back()}
+              className="p-2 hover:bg-gray-100 rounded transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </button>
+            <h2 className="text-2xl font-bold text-gray-900">고양이 수정</h2>
+          </div>
+          <button
+            onClick={() => setConfirmDelete(true)}
+            className="p-2 hover:bg-red-50 rounded transition-colors text-gray-400 hover:text-red-600"
+          >
+            <Trash2 className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">이름 *</label>
+            <Input
+              value={form.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder="예: 나비"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">품종 (한국어)</label>
+            <Input
+              value={form.breed_name_ko}
+              onChange={(e) => set("breed_name_ko", e.target.value)}
+              placeholder="예: 코리안숏헤어"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">품종 (영어)</label>
+            <Input
+              value={form.breed_name_en}
+              onChange={(e) => set("breed_name_en", e.target.value)}
+              placeholder="예: Korean Shorthair"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">나이 (개월)</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.age_months}
+              onChange={(e) => set("age_months", e.target.value)}
+              placeholder="예: 14"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">성별</label>
+            <div className="flex gap-2">
+              {(["M", "F", "미상"] as const).map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => set("gender", g)}
+                  className={`flex-1 py-2 border-2 rounded-lg text-sm font-medium transition-colors ${
+                    form.gender === g
+                      ? "border-gray-900 bg-gray-900 text-white"
+                      : "border-gray-300 text-gray-700 hover:border-gray-500"
+                  }`}
+                >
+                  {g === "M" ? "수컷" : g === "F" ? "암컷" : "미상"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">프로필 이미지 URL (선택)</label>
+            <Input
+              value={form.profile_image_url}
+              onChange={(e) => set("profile_image_url", e.target.value)}
+              placeholder="https://..."
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={submitting || !form.name.trim()}
+            className="w-full bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50 h-11"
+          >
+            {submitting ? "저장 중..." : "저장하기"}
+          </Button>
+        </form>
+      </div>
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>고양이 삭제</AlertDialogTitle>
+            <AlertDialogDescription>
+              &ldquo;{cat.name}&rdquo; 정보를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>삭제</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/app/my-cats/new/page.tsx
+++ b/frontend/src/app/my-cats/new/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Navigation } from "@/components/layout/Navigation";
+import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
+import { getZipsaToken, createUserCat } from "@/lib/api";
+
+export default function NewCatPage() {
+  const router = useRouter();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    breed_name_ko: "",
+    breed_name_en: "",
+    age_months: "",
+    gender: "미상",
+    profile_image_url: "",
+  });
+
+  const set = (key: keyof typeof form, value: string) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    const token = getZipsaToken();
+    if (!token) return;
+    setSubmitting(true);
+    try {
+      await createUserCat(token, {
+        name: form.name.trim(),
+        breed_name_ko: form.breed_name_ko.trim(),
+        breed_name_en: form.breed_name_en.trim(),
+        age_months: form.age_months ? parseInt(form.age_months, 10) : 0,
+        gender: form.gender,
+        profile_image_url: form.profile_image_url.trim() || null,
+      });
+      router.push("/my-cats");
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation onMenuClick={() => setDrawerOpen(true)} />
+      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      <div className="max-w-[480px] mx-auto px-6 py-12">
+        <div className="flex items-center gap-3 mb-8">
+          <button
+            onClick={() => router.back()}
+            className="p-2 hover:bg-gray-100 rounded transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5 text-gray-600" />
+          </button>
+          <h2 className="text-2xl font-bold text-gray-900">고양이 등록</h2>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">이름 *</label>
+            <Input
+              value={form.name}
+              onChange={(e) => set("name", e.target.value)}
+              placeholder="예: 나비"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">품종 (한국어)</label>
+            <Input
+              value={form.breed_name_ko}
+              onChange={(e) => set("breed_name_ko", e.target.value)}
+              placeholder="예: 코리안숏헤어"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">품종 (영어)</label>
+            <Input
+              value={form.breed_name_en}
+              onChange={(e) => set("breed_name_en", e.target.value)}
+              placeholder="예: Korean Shorthair"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">나이 (개월)</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.age_months}
+              onChange={(e) => set("age_months", e.target.value)}
+              placeholder="예: 14"
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">성별</label>
+            <div className="flex gap-2">
+              {(["M", "F", "미상"] as const).map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => set("gender", g)}
+                  className={`flex-1 py-2 border-2 rounded-lg text-sm font-medium transition-colors ${
+                    form.gender === g
+                      ? "border-gray-900 bg-gray-900 text-white"
+                      : "border-gray-300 text-gray-700 hover:border-gray-500"
+                  }`}
+                >
+                  {g === "M" ? "수컷" : g === "F" ? "암컷" : "미상"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">프로필 이미지 URL (선택)</label>
+            <Input
+              value={form.profile_image_url}
+              onChange={(e) => set("profile_image_url", e.target.value)}
+              placeholder="https://..."
+              className="border-2 border-gray-300 focus:border-gray-900"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={submitting || !form.name.trim()}
+            className="w-full bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50 h-11"
+          >
+            {submitting ? "등록 중..." : "등록하기"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/my-cats/page.tsx
+++ b/frontend/src/app/my-cats/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Navigation } from "@/components/layout/Navigation";
+import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
+import { UserCatCard } from "@/components/chat/UserCatCard";
+import { getZipsaToken, getUserCats, type UserCat } from "@/lib/api";
+
+function AddCatCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="border-2 border-dashed border-gray-400 rounded-lg p-6 bg-white hover:bg-gray-50 transition-colors min-h-[320px] flex items-center justify-center"
+    >
+      <div className="text-center space-y-3">
+        <div className="w-16 h-16 rounded-full border-2 border-dashed border-gray-400 flex items-center justify-center mx-auto">
+          <Plus className="w-8 h-8 text-gray-400" />
+        </div>
+        <p className="text-sm text-gray-500 font-medium">고양이 추가하기</p>
+      </div>
+    </button>
+  );
+}
+
+export default function MyCatsPage() {
+  const router = useRouter();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [cats, setCats] = useState<UserCat[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const token = getZipsaToken();
+    if (!token) { setLoading(false); return; }
+    getUserCats(token)
+      .then(setCats)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation onMenuClick={() => setDrawerOpen(true)} />
+      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      <div className="max-w-[960px] mx-auto px-8 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl font-bold text-gray-900">내 고양이</h2>
+          <Button
+            variant="outline"
+            className="border-2 border-gray-900 text-gray-900 hover:bg-gray-100 gap-2"
+            onClick={() => router.push("/my-cats/new")}
+          >
+            <Plus className="w-5 h-5" />
+            고양이 등록하기
+          </Button>
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-20">
+            <span className="inline-flex gap-1 items-center">
+              <span className="w-2 h-2 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "0ms" }} />
+              <span className="w-2 h-2 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "150ms" }} />
+              <span className="w-2 h-2 rounded-full bg-gray-400 animate-bounce" style={{ animationDelay: "300ms" }} />
+            </span>
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-6">
+            {cats.map((cat) => (
+              <UserCatCard
+                key={cat.cat_id}
+                cat={cat}
+                onEdit={() => router.push(`/my-cats/${cat.cat_id}`)}
+              />
+            ))}
+            <AddCatCard onClick={() => router.push("/my-cats/new")} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/RescueCatCard.tsx
+++ b/frontend/src/components/chat/RescueCatCard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Cat } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { RescueCat } from "@/lib/api";
+
+interface RescueCatCardProps {
+  cat: RescueCat;
+}
+
+export function RescueCatCard({ cat }: RescueCatCardProps) {
+  return (
+    <div className="border-2 border-gray-300 bg-white shadow-md rounded-lg overflow-hidden">
+      {/* 이미지 */}
+      <div className="relative w-full h-[280px] bg-gray-200 border-b-2 border-gray-300 overflow-hidden flex items-center justify-center">
+        {cat.image_url ? (
+          <img
+            src={cat.image_url}
+            alt={cat.breed || "구조묘"}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="text-center">
+            <Cat className="w-16 h-16 text-gray-400 mx-auto mb-2" strokeWidth={1} />
+            <p className="text-gray-400 font-mono text-xs">CAT IMAGE</p>
+          </div>
+        )}
+        <div className="absolute top-3 left-3">
+          <Badge className="bg-gray-900 text-white border-0 rounded-full px-3 py-1 text-xs">
+            입양 가능
+          </Badge>
+        </div>
+      </div>
+
+      {/* 카드 바디 */}
+      <div className="p-5 space-y-3">
+        {/* 품종 */}
+        <div>
+          <h3 className="text-xl font-bold text-gray-900">{cat.breed || "품종 미상"}</h3>
+        </div>
+
+        {/* 정보 태그: 나이, 성별, 중성화 */}
+        <div className="flex flex-wrap gap-2">
+          {cat.age && (
+            <Badge variant="outline" className="border-2 border-gray-400 text-gray-700 rounded-full px-3 py-1 text-xs">
+              {cat.age}
+            </Badge>
+          )}
+          {cat.sex && (
+            <Badge variant="outline" className="border-2 border-gray-400 text-gray-700 rounded-full px-3 py-1 text-xs">
+              {cat.sex}
+            </Badge>
+          )}
+          {cat.neutered && cat.neutered !== "미상" && (
+            <Badge variant="outline" className="border-2 border-gray-400 text-gray-700 rounded-full px-3 py-1 text-xs">
+              {cat.neutered}
+            </Badge>
+          )}
+        </div>
+
+        <div className="h-[2px] bg-gray-300" />
+
+        {/* 특이사항 */}
+        {cat.feature && (
+          <p className="text-sm text-gray-700 leading-relaxed">{cat.feature}</p>
+        )}
+
+        {/* 보호소 정보 */}
+        <div className="space-y-1">
+          {cat.shelter_name && (
+            <p className="text-sm font-medium text-gray-900">{cat.shelter_name}</p>
+          )}
+          {cat.shelter_address && (
+            <p className="text-xs text-gray-500">{cat.shelter_address}</p>
+          )}
+          {cat.notice_end_date && (
+            <p className="text-xs text-gray-400">공고 마감: {cat.notice_end_date}</p>
+          )}
+        </div>
+
+        {/* 입양 문의 버튼 */}
+        {cat.shelter_phone ? (
+          <a
+            href={`tel:${cat.shelter_phone}`}
+            className="block w-full bg-gray-900 text-white text-sm font-medium text-center py-2.5 rounded-lg hover:bg-gray-800 transition-colors"
+          >
+            입양 문의하기 ({cat.shelter_phone})
+          </a>
+        ) : (
+          <button
+            disabled
+            className="w-full bg-gray-300 text-gray-500 text-sm font-medium py-2.5 rounded-lg cursor-not-allowed"
+          >
+            입양 문의하기
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/UserCatCard.tsx
+++ b/frontend/src/components/chat/UserCatCard.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Cat } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { UserCat } from "@/lib/api";
+
+interface UserCatCardProps {
+  cat: UserCat;
+  onEdit?: () => void;
+}
+
+function formatAge(months: number): string {
+  const years = Math.floor(months / 12);
+  const rem = months % 12;
+  if (years > 0 && rem > 0) return `${years}살 ${rem}개월`;
+  if (years > 0) return `${years}살`;
+  return `${rem}개월`;
+}
+
+function genderLabel(g: string): string {
+  if (g === "M") return "수컷";
+  if (g === "F") return "암컷";
+  return g;
+}
+
+export function UserCatCard({ cat, onEdit }: UserCatCardProps) {
+  const lastVaccination = cat.health?.vaccinations?.[cat.health.vaccinations.length - 1];
+
+  return (
+    <div className="border-2 border-gray-300 rounded-lg p-6 bg-white space-y-4">
+      {/* 이미지 플레이스홀더 */}
+      <div className="flex justify-center">
+        <div className="w-24 h-24 rounded-full bg-gray-200 border-2 border-gray-300 overflow-hidden flex items-center justify-center">
+          {cat.profile_image_url ? (
+            <img
+              src={cat.profile_image_url}
+              alt={cat.name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <Cat className="w-12 h-12 text-gray-400" strokeWidth={1} />
+          )}
+        </div>
+      </div>
+
+      {/* 이름 + 품종 + 나이 */}
+      <div className="text-center space-y-2">
+        <h3 className="text-xl font-bold text-gray-900">{cat.name}</h3>
+        <p className="text-sm text-gray-600">
+          {cat.breed_name_ko || "품종 미상"} · {formatAge(cat.age_months)}
+        </p>
+
+        {/* 성별 */}
+        {cat.gender && cat.gender !== "미상" && (
+          <div className="flex justify-center">
+            <Badge
+              variant="outline"
+              className="border-2 border-gray-400 rounded-full px-3 py-1 text-xs text-gray-700"
+            >
+              {genderLabel(cat.gender)}
+            </Badge>
+          </div>
+        )}
+
+        {/* 접종 정보 */}
+        {lastVaccination && (
+          <div className="pt-2 border-t-2 border-gray-200">
+            <p className="text-xs text-gray-500">{lastVaccination.label}</p>
+            <p className="text-xs text-gray-400">{lastVaccination.date}</p>
+          </div>
+        )}
+      </div>
+
+      {/* 수정 버튼 */}
+      <Button
+        variant="outline"
+        className="w-full border-2 border-gray-900 text-gray-900 hover:bg-gray-100 text-sm"
+        onClick={onEdit}
+      >
+        수정하기
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -171,6 +171,22 @@ export interface ChatSession {
   updated_at: string;
 }
 
+export interface RescueCat {
+  animal_id: string;
+  breed: string;
+  age: string;
+  sex: string;
+  neutered: string;
+  feature: string;
+  image_url: string;
+  shelter_name: string;
+  shelter_address: string;
+  shelter_phone: string;
+  notice_end_date: string;
+  sido: string;
+  sigungu: string;
+}
+
 export interface ChatMessage {
   message_id: string;
   session_id: string;
@@ -178,6 +194,7 @@ export interface ChatMessage {
   content: string;
   recommendations: Recommendation[];
   rag_docs: RagDoc[];
+  rescue_cats: RescueCat[];
   created_at: string;
 }
 
@@ -215,12 +232,104 @@ export async function getMessages(token: string, sessionId: string): Promise<Cha
   return res.json();
 }
 
+// ── UserCat ──────────────────────────────────────────────────────────────────
+
+export interface VaccinationInfo {
+  label: string;
+  date: string;
+}
+
+export interface UserCatHealth {
+  vaccinations: VaccinationInfo[];
+}
+
+export interface UserCat {
+  cat_id: string;
+  user_id: string;
+  name: string;
+  age_months: number;
+  gender: string;
+  breed_name_ko: string;
+  breed_name_en: string;
+  profile_image_url: string | null;
+  health: UserCatHealth;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserCatCreateRequest {
+  name: string;
+  age_months?: number;
+  gender?: string;
+  breed_name_ko?: string;
+  breed_name_en?: string;
+  profile_image_url?: string | null;
+  health?: Partial<UserCatHealth>;
+}
+
+export interface UserCatUpdateRequest {
+  name?: string;
+  age_months?: number;
+  gender?: string;
+  breed_name_ko?: string;
+  breed_name_en?: string;
+  profile_image_url?: string | null;
+  health?: Partial<UserCatHealth>;
+}
+
+export async function getUserCats(token: string): Promise<UserCat[]> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/cats`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getUserCats failed: ${res.status}`);
+  return res.json();
+}
+
+export async function createUserCat(token: string, data: UserCatCreateRequest): Promise<UserCat> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/cats`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(`createUserCat failed: ${res.status}`);
+  return res.json();
+}
+
+export async function updateUserCat(
+  token: string,
+  catId: string,
+  data: UserCatUpdateRequest,
+): Promise<UserCat> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/cats/${catId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(`updateUserCat failed: ${res.status}`);
+  return res.json();
+}
+
+export async function deleteUserCat(token: string, catId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/cats/${catId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`deleteUserCat failed: ${res.status}`);
+}
+
 export async function* streamChat(
   token: string,
   sessionId: string,
   message: string,
   userProfile?: UserProfileResponse | null,
-): AsyncGenerator<{ type: string; content?: string; data?: unknown }> {
+): AsyncGenerator<
+  | { type: "token"; content: string }
+  | { type: "recommendations"; data: Recommendation[] }
+  | { type: "rag_docs"; data: RagDoc[] }
+  | { type: "rescue_cats"; data: RescueCat[] }
+  | { type: "error"; content: string }
+  | { type: string; content?: string; data?: unknown }
+> {
   const res = await fetch(`${API_BASE}/api/v1/chat/stream`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,5 +2,5 @@ export { default } from "next-auth/middleware";
 
 export const config = {
   // 보호가 필요한 경로만 명시 (나머지는 public)
-  matcher: ["/chat/:path*", "/onboarding/:path*", "/profile/:path*"],
+  matcher: ["/chat/:path*", "/onboarding/:path*", "/profile/:path*", "/my-cats/:path*"],
 };


### PR DESCRIPTION
## Summary

- `api.ts`: RescueCat 타입, rescue_cats 스트리밍 이벤트, UserCat CRUD 함수 추가
- `RescueCatCard`: 보호소 고양이 카드 (이미지, 품종/나이/성별/중성화, 보호소 정보, tel 링크)
- `UserCatCard`: 내 고양이 카드 (프로필 이미지, 이름/품종/나이/성별, 백신 정보)
- `chat/[id]/page.tsx`: rescueCats 상태, breed/rescue 탭 패널 UI
- `/my-cats` 페이지: 고양이 목록 3열 그리드 + AddCatCard
- `/my-cats/new`: 고양이 등록 폼
- `/my-cats/[id]`: 수정/삭제 폼 (AlertDialog 확인)
- `middleware.ts`: `/my-cats` 보호 경로 추가

## Test plan

- [ ] Liaison 채팅 응답 시 우측 패널에 RescueCatCard 표시 확인
- [ ] /my-cats 목록 조회, 추가, 수정, 삭제 동작 확인
- [ ] 로그인 없이 /my-cats 접근 시 리다이렉트 확인

Closes #30
Closes #31