### PR TITLE
feat: 냥심 번역기 (#35 #36 #37)

### DIFF
--- a/frontend/src/app/meme/page.tsx
+++ b/frontend/src/app/meme/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Navigation } from "@/components/layout/Navigation";
+import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
+import { getZipsaToken, analyzeMeme, createUserCat, MemeAnalyzeResponse } from "@/lib/api";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+
+export default function MemePage() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [context, setContext] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<MemeAnalyzeResponse | null>(null);
+
+  // 내 고양이 등록 다이얼로그
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [catName, setCatName] = useState("");
+  const [registering, setRegistering] = useState(false);
+
+  const handleFileSelect = (file: File) => {
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+    setResult(null);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith("image/")) handleFileSelect(file);
+  };
+
+  const handleAnalyze = async () => {
+    if (!selectedFile) return;
+    const token = getZipsaToken();
+    if (!token) return;
+    setLoading(true);
+    try {
+      const res = await analyzeMeme(token, selectedFile, context);
+      setResult(res);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRegisterCat = async () => {
+    if (!catName.trim() || !result) return;
+    const token = getZipsaToken();
+    if (!token) return;
+    setRegistering(true);
+    try {
+      await createUserCat(token, {
+        name: catName.trim(),
+        breed_name_ko: result.breed_guess,
+        age_months: result.age_months,
+        profile_image_url: `${API_BASE}${result.image_url}`,
+        meme_text: result.meme_text,
+      });
+      router.push("/my-cats");
+    } finally {
+      setRegistering(false);
+      setDialogOpen(false);
+    }
+  };
+
+  const openRegisterDialog = () => {
+    setCatName("");
+    setDialogOpen(true);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <Navigation onMenuClick={() => setDrawerOpen(true)} />
+      <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
+
+      <div className="flex-1 flex flex-col items-center justify-center py-12">
+        <div className="w-full max-w-[1200px] px-8">
+          <div className="text-center mb-12">
+            <h1 className="text-4xl font-bold text-gray-900 mb-3">냥심 번역기</h1>
+            <p className="text-gray-500 text-base">
+              고양이 사진을 올리면 AI가 고양이의 속마음을 대신 전해드립니다
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-16">
+            {/* Left Column — 업로드 */}
+            <div className="flex flex-col items-center justify-center">
+              {/* 업로드 박스 */}
+              <div
+                className={`w-[420px] h-[420px] border-4 border-dashed rounded-lg flex flex-col items-center justify-center cursor-pointer transition-colors overflow-hidden ${
+                  dragging
+                    ? "border-gray-700 bg-gray-100"
+                    : "border-gray-400 bg-white hover:border-gray-500 hover:bg-gray-50"
+                }`}
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+                onDragLeave={() => setDragging(false)}
+                onDrop={handleDrop}
+              >
+                {previewUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={previewUrl}
+                    alt="선택된 고양이 사진"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <>
+                    <Upload className="w-12 h-12 text-gray-400 mb-4" strokeWidth={2} />
+                    <p className="text-gray-600 text-center px-8 leading-relaxed">
+                      고양이 사진을 드래그하거나<br />클릭해서 올려주세요
+                    </p>
+                  </>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleFileSelect(file);
+                }}
+              />
+
+              {/* 컨텍스트 입력 */}
+              <div className="w-[420px] mt-6 relative">
+                <Input
+                  placeholder="한 마디 덧붙여 주세요 (선택사항, 예: 오늘 밥을 거부했어요)"
+                  className="w-full border-2 border-gray-300 focus:border-gray-400 rounded-lg px-4 py-3 pr-16"
+                  maxLength={100}
+                  value={context}
+                  onChange={(e) => setContext(e.target.value)}
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
+                  {context.length}/100
+                </span>
+              </div>
+
+              {/* 분석 버튼 */}
+              <Button
+                className="w-[420px] mt-4 bg-gray-900 text-white hover:bg-gray-800 border-0 rounded-lg py-6 text-base font-medium disabled:opacity-50"
+                disabled={!selectedFile || loading}
+                onClick={handleAnalyze}
+              >
+                {loading ? (
+                  <span className="flex items-center gap-2">
+                    <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                    분석 중...
+                  </span>
+                ) : (
+                  "분석 시작"
+                )}
+              </Button>
+            </div>
+
+            {/* Right Column — 결과 */}
+            <div className="flex flex-col items-center justify-center">
+              {/* 폴라로이드 카드 */}
+              <div
+                className="bg-white p-6 shadow-lg"
+                style={{ transform: "rotate(2deg)", borderRadius: "4px" }}
+              >
+                <div className="w-[320px] h-[320px] bg-gray-200 border-2 border-gray-300 flex items-center justify-center overflow-hidden">
+                  {result ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={`${API_BASE}${result.image_url}`}
+                      alt="분석된 고양이"
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="text-center">
+                      <div className="text-6xl mb-2">🐱</div>
+                      <p className="text-gray-500 font-mono text-xs">CAT PHOTO</p>
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-4 px-2">
+                  {result ? (
+                    <>
+                      <p className="text-gray-800 italic text-center leading-relaxed text-sm">
+                        {result.meme_text}
+                      </p>
+                      <div className="flex justify-center gap-2 mt-3">
+                        <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+                          {result.breed_guess}
+                        </span>
+                        <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+                          {result.age_guess}
+                        </span>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-gray-800 italic text-center leading-relaxed text-sm">
+                      "인간아, 지금 당장 간식을<br />내놓지 않으면 후회할 거다냥"
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* 액션 버튼 */}
+              <div className="flex gap-3 mt-8">
+                <Button
+                  className="bg-gray-900 text-white hover:bg-gray-800 border-0 px-6 py-2 disabled:opacity-50"
+                  disabled={!result}
+                  onClick={openRegisterDialog}
+                >
+                  내 고양이로 등록
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 내 고양이 등록 다이얼로그 */}
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>내 고양이로 등록</AlertDialogTitle>
+          </AlertDialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-gray-700">이름 *</label>
+              <Input
+                placeholder="예: 나비"
+                value={catName}
+                onChange={(e) => setCatName(e.target.value)}
+                className="border-2 border-gray-300 focus:border-gray-900"
+                autoFocus
+              />
+            </div>
+            {result && (
+              <div className="text-sm text-gray-500 space-y-1">
+                <p>품종: {result.breed_guess || "—"}</p>
+                <p>나이: {result.age_months ? `약 ${result.age_months}개월` : "—"}</p>
+              </div>
+            )}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={registering}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={!catName.trim() || registering}
+              onClick={(e) => {
+                e.preventDefault();
+                handleRegisterCat();
+              }}
+              className="bg-gray-900 text-white hover:bg-gray-800"
+            >
+              {registering ? "등록 중..." : "등록하기"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/app/my-cats/[id]/page.tsx
+++ b/frontend/src/app/my-cats/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { ArrowLeft, Trash2 } from "lucide-react";
+import { ArrowLeft, Trash2, Cat } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Navigation } from "@/components/layout/Navigation";
@@ -17,14 +17,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { getZipsaToken, getUserCats, updateUserCat, deleteUserCat, type UserCat } from "@/lib/api";
+import {
+  getZipsaToken,
+  getUserCats,
+  updateUserCat,
+  deleteUserCat,
+  uploadCatImage,
+  type UserCat,
+} from "@/lib/api";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export default function EditCatPage() {
   const router = useRouter();
   const { id } = useParams<{ id: string }>();
+  const imageInputRef = useRef<HTMLInputElement>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [cat, setCat] = useState<UserCat | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [form, setForm] = useState({
     name: "",
@@ -33,6 +44,7 @@ export default function EditCatPage() {
     age_months: "",
     gender: "미상",
     profile_image_url: "",
+    meme_text: "",
   });
 
   useEffect(() => {
@@ -50,6 +62,7 @@ export default function EditCatPage() {
             age_months: String(found.age_months),
             gender: found.gender,
             profile_image_url: found.profile_image_url ?? "",
+            meme_text: found.meme_text ?? "",
           });
         }
       })
@@ -58,6 +71,21 @@ export default function EditCatPage() {
 
   const set = (key: keyof typeof form, value: string) =>
     setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const token = getZipsaToken();
+    if (!token) return;
+    setUploading(true);
+    try {
+      const { image_url } = await uploadCatImage(token, file);
+      set("profile_image_url", `${API_BASE}${image_url}`);
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,6 +101,7 @@ export default function EditCatPage() {
         age_months: form.age_months ? parseInt(form.age_months, 10) : 0,
         gender: form.gender,
         profile_image_url: form.profile_image_url.trim() || null,
+        meme_text: form.meme_text.trim() || null,
       });
       router.push("/my-cats");
     } catch {
@@ -122,6 +151,55 @@ export default function EditCatPage() {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-5">
+          {/* 프로필 이미지 업로드 */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700">프로필 이미지</label>
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => imageInputRef.current?.click()}
+                className="w-20 h-20 rounded-full bg-gray-100 border-2 border-gray-300 overflow-hidden flex items-center justify-center hover:border-gray-500 transition-colors shrink-0"
+              >
+                {form.profile_image_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={form.profile_image_url}
+                    alt="프로필"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <Cat className="w-8 h-8 text-gray-400" strokeWidth={1} />
+                )}
+              </button>
+              <div className="space-y-1">
+                <button
+                  type="button"
+                  onClick={() => imageInputRef.current?.click()}
+                  disabled={uploading}
+                  className="text-sm text-gray-700 underline underline-offset-2 disabled:opacity-50"
+                >
+                  {uploading ? "업로드 중..." : "이미지 변경"}
+                </button>
+                {form.profile_image_url && (
+                  <button
+                    type="button"
+                    onClick={() => set("profile_image_url", "")}
+                    className="block text-xs text-gray-400 hover:text-red-500 transition-colors"
+                  >
+                    삭제
+                  </button>
+                )}
+              </div>
+            </div>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleImageUpload}
+            />
+          </div>
+
           <div className="space-y-1">
             <label className="text-sm font-medium text-gray-700">이름 *</label>
             <Input
@@ -185,13 +263,16 @@ export default function EditCatPage() {
           </div>
 
           <div className="space-y-1">
-            <label className="text-sm font-medium text-gray-700">프로필 이미지 URL (선택)</label>
-            <Input
-              value={form.profile_image_url}
-              onChange={(e) => set("profile_image_url", e.target.value)}
-              placeholder="https://..."
-              className="border-2 border-gray-300 focus:border-gray-900"
+            <label className="text-sm font-medium text-gray-700">냥심 한 마디</label>
+            <textarea
+              value={form.meme_text}
+              onChange={(e) => set("meme_text", e.target.value)}
+              placeholder={`예: "인간아, 지금 당장 간식을 내놓지 않으면 후회할 거다냥"`}
+              maxLength={200}
+              rows={3}
+              className="w-full border-2 border-gray-300 focus:border-gray-900 rounded-md px-3 py-2 text-sm text-gray-900 outline-none resize-none transition-colors"
             />
+            <p className="text-xs text-gray-400 text-right">{form.meme_text.length}/200</p>
           </div>
 
           <Button

--- a/frontend/src/app/my-cats/page.tsx
+++ b/frontend/src/app/my-cats/page.tsx
@@ -13,7 +13,7 @@ function AddCatCard({ onClick }: { onClick: () => void }) {
   return (
     <button
       onClick={onClick}
-      className="border-2 border-dashed border-gray-400 rounded-lg p-6 bg-white hover:bg-gray-50 transition-colors min-h-[320px] flex items-center justify-center"
+      className="border-2 border-dashed border-gray-400 rounded-lg p-6 bg-white hover:bg-gray-50 transition-colors min-h-[320px] flex items-center justify-center w-full"
     >
       <div className="text-center space-y-3">
         <div className="w-16 h-16 rounded-full border-2 border-dashed border-gray-400 flex items-center justify-center mx-auto">
@@ -50,7 +50,7 @@ export default function MyCatsPage() {
           <h2 className="text-3xl font-bold text-gray-900">내 고양이</h2>
           <Button
             variant="outline"
-            className="border-2 border-gray-900 text-gray-900 hover:bg-gray-100 gap-2"
+            className="border-2 border-gray-900 bg-white text-gray-900 hover:bg-gray-100 gap-2"
             onClick={() => router.push("/my-cats/new")}
           >
             <Plus className="w-5 h-5" />

--- a/frontend/src/components/chat/UserCatCard.tsx
+++ b/frontend/src/components/chat/UserCatCard.tsx
@@ -63,6 +63,13 @@ export function UserCatCard({ cat, onEdit }: UserCatCardProps) {
           </div>
         )}
 
+        {/* 냥심 한 마디 */}
+        {cat.meme_text && (
+          <p className="text-xs text-gray-500 italic border-t-2 border-gray-100 pt-2">
+            {cat.meme_text}
+          </p>
+        )}
+
         {/* 접종 정보 */}
         {lastVaccination && (
           <div className="pt-2 border-t-2 border-gray-200">
@@ -75,7 +82,7 @@ export function UserCatCard({ cat, onEdit }: UserCatCardProps) {
       {/* 수정 버튼 */}
       <Button
         variant="outline"
-        className="w-full border-2 border-gray-900 text-gray-900 hover:bg-gray-100 text-sm"
+        className="w-full border-2 border-gray-900 bg-white text-gray-900 hover:bg-gray-100 text-sm"
         onClick={onEdit}
       >
         수정하기

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -252,6 +252,7 @@ export interface UserCat {
   breed_name_ko: string;
   breed_name_en: string;
   profile_image_url: string | null;
+  meme_text: string | null;
   health: UserCatHealth;
   created_at: string;
   updated_at: string;
@@ -264,6 +265,7 @@ export interface UserCatCreateRequest {
   breed_name_ko?: string;
   breed_name_en?: string;
   profile_image_url?: string | null;
+  meme_text?: string | null;
   health?: Partial<UserCatHealth>;
 }
 
@@ -274,7 +276,20 @@ export interface UserCatUpdateRequest {
   breed_name_ko?: string;
   breed_name_en?: string;
   profile_image_url?: string | null;
+  meme_text?: string | null;
   health?: Partial<UserCatHealth>;
+}
+
+export async function uploadCatImage(token: string, image: File): Promise<{ image_url: string }> {
+  const form = new FormData();
+  form.append("image", image);
+  const res = await fetch(`${API_BASE}/api/v1/users/me/cats/upload-image`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(`uploadCatImage failed: ${res.status}`);
+  return res.json();
 }
 
 export async function getUserCats(token: string): Promise<UserCat[]> {
@@ -306,6 +321,33 @@ export async function updateUserCat(
     body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error(`updateUserCat failed: ${res.status}`);
+  return res.json();
+}
+
+// ── Meme ─────────────────────────────────────────────────────────────────────
+
+export interface MemeAnalyzeResponse {
+  meme_text: string;
+  breed_guess: string;
+  age_guess: string;
+  age_months: number;
+  image_url: string;
+}
+
+export async function analyzeMeme(
+  token: string,
+  image: File,
+  context: string,
+): Promise<MemeAnalyzeResponse> {
+  const form = new FormData();
+  form.append("image", image);
+  form.append("context", context);
+  const res = await fetch(`${API_BASE}/api/v1/meme/analyze`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error(`analyzeMeme failed: ${res.status}`);
   return res.json();
 }
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,5 +2,5 @@ export { default } from "next-auth/middleware";
 
 export const config = {
   // 보호가 필요한 경로만 명시 (나머지는 public)
-  matcher: ["/chat/:path*", "/onboarding/:path*", "/profile/:path*", "/my-cats/:path*"],
+  matcher: ["/chat/:path*", "/onboarding/:path*", "/profile/:path*", "/my-cats/:path*", "/meme/:path*"],
 };

--- a/src/api/routers/cats.py
+++ b/src/api/routers/cats.py
@@ -3,11 +3,13 @@
 """
 import logging
 import os
+import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import certifi
 from bson import ObjectId
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from src.api.dependencies import get_current_user
@@ -41,6 +43,7 @@ def _doc_to_response(doc: dict) -> UserCatResponse:
         breed_name_ko=doc.get("breed_name_ko", ""),
         breed_name_en=doc.get("breed_name_en", ""),
         profile_image_url=doc.get("profile_image_url"),
+        meme_text=doc.get("meme_text"),
         health=UserCatHealth(**health_data) if health_data else UserCatHealth(),
         created_at=doc["created_at"],
         updated_at=doc["updated_at"],
@@ -121,3 +124,20 @@ async def delete_cat(
     result = await col.delete_one({"_id": ObjectId(cat_id), "user_id": current_user.user_id})
     if result.deleted_count == 0:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="고양이를 찾을 수 없습니다.")
+
+
+_CATS_STATIC_DIR = Path(__file__).parents[3] / "static" / "cats"
+
+
+@router.post("/upload-image")
+async def upload_cat_image(
+    image: UploadFile = File(...),
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict:
+    """고양이 프로필 이미지 업로드 → /static/cats/{uuid}.jpg URL 반환."""
+    _CATS_STATIC_DIR.mkdir(parents=True, exist_ok=True)
+    image_bytes = await image.read()
+    ext = Path(image.filename or "image.jpg").suffix or ".jpg"
+    file_name = f"{uuid.uuid4()}{ext}"
+    (_CATS_STATIC_DIR / file_name).write_bytes(image_bytes)
+    return {"image_url": f"/static/cats/{file_name}"}

--- a/src/api/routers/meme.py
+++ b/src/api/routers/meme.py
@@ -1,8 +1,95 @@
 """
-/api/v1/meme — 냥심 번역기 라우터 (stub)
+/api/v1/meme — 냥심 번역기 라우터
 
-TODO: Vision AI 연동 냥심 번역기 엔드포인트
+고양이 사진 업로드 → GPT-4o-mini Vision → 시니컬한 밈 텍스트 생성
 """
-from fastapi import APIRouter
+import base64
+import json
+import os
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from openai import AsyncOpenAI
+
+from src.api.dependencies import get_current_user
+from src.core.models.auth import AuthUser
+from src.core.models.meme import MemeAnalyzeResponse
 
 router = APIRouter(prefix="/api/v1/meme", tags=["Meme"])
+
+_STATIC_DIR = Path(__file__).parents[3] / "static" / "meme"
+
+_VISION_SYSTEM = """당신은 도도하고 시니컬한 고양이입니다. 사진 속 고양이를 분석해 밈 텍스트를 생성하세요.
+반드시 아래 JSON만 출력하세요:
+{"meme_text": "...", "breed_guess": "...", "age_guess": "...", "age_months": 0}
+- meme_text: 고양이 시점의 시니컬한 한 마디 (따옴표 포함, 20~60자)
+- breed_guess: 추정 품종명만, 조사/문장 없이 (예: "래그돌", "코리안숏헤어", "페르시안")
+- age_guess: 표시용 나이 문자열 (예: "약 2살 추정", "6개월 미만")
+- age_months: 추정 나이(개월 수, 정수). 2살이면 24, 6개월이면 6"""
+
+
+@router.post("/analyze", response_model=MemeAnalyzeResponse)
+async def analyze_meme(
+    image: UploadFile = File(...),
+    context: str = Form(""),
+    current_user: AuthUser = Depends(get_current_user),
+) -> MemeAnalyzeResponse:
+    """고양이 사진 → Vision AI → 시니컬한 밈 텍스트 생성."""
+    _STATIC_DIR.mkdir(parents=True, exist_ok=True)
+
+    # 1. 이미지 읽기 + base64 인코딩
+    image_bytes = await image.read()
+    image_b64 = base64.b64encode(image_bytes).decode()
+    ext = Path(image.filename or "image.jpg").suffix or ".jpg"
+    media_type = image.content_type or "image/jpeg"
+
+    # 2. 파일 저장
+    file_name = f"{uuid.uuid4()}{ext}"
+    save_path = _STATIC_DIR / file_name
+    save_path.write_bytes(image_bytes)
+    image_url = f"/static/meme/{file_name}"
+
+    # 3. GPT-4o-mini Vision 호출
+    user_content: list = [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:{media_type};base64,{image_b64}"},
+        }
+    ]
+    if context:
+        user_content.append({"type": "text", "text": context})
+
+    client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    try:
+        response = await client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": _VISION_SYSTEM},
+                {"role": "user", "content": user_content},
+            ],
+            response_format={"type": "json_object"},
+            max_tokens=256,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Vision API 호출 실패: {e}",
+        )
+
+    raw = response.choices[0].message.content or "{}"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Vision API 응답 파싱 실패",
+        )
+
+    return MemeAnalyzeResponse(
+        meme_text=data.get("meme_text", "..."),
+        breed_guess=data.get("breed_guess", "품종 불명"),
+        age_guess=data.get("age_guess", "나이 불명"),
+        age_months=int(data.get("age_months", 0)),
+        image_url=image_url,
+    )

--- a/src/core/models/meme.py
+++ b/src/core/models/meme.py
@@ -1,0 +1,12 @@
+"""
+밈 분석 Pydantic 모델.
+"""
+from pydantic import BaseModel
+
+
+class MemeAnalyzeResponse(BaseModel):
+    meme_text: str
+    breed_guess: str   # 품종명만 (예: "래그돌", "코리안숏헤어")
+    age_guess: str     # 표시용 문자열 (예: "약 2살 추정")
+    age_months: int    # 등록용 숫자 (예: 24)
+    image_url: str     # /static/meme/{uuid}.jpg

--- a/src/core/models/user_cat.py
+++ b/src/core/models/user_cat.py
@@ -23,6 +23,7 @@ class UserCatCreateRequest(BaseModel):
     breed_name_ko: str = ""
     breed_name_en: str = ""
     profile_image_url: Optional[str] = None
+    meme_text: Optional[str] = None
     health: Optional[UserCatHealth] = None
 
 
@@ -33,6 +34,7 @@ class UserCatUpdateRequest(BaseModel):
     breed_name_ko: Optional[str] = None
     breed_name_en: Optional[str] = None
     profile_image_url: Optional[str] = None
+    meme_text: Optional[str] = None
     health: Optional[UserCatHealth] = None
 
 
@@ -45,6 +47,7 @@ class UserCatResponse(BaseModel):
     breed_name_ko: str = ""
     breed_name_en: str = ""
     profile_image_url: Optional[str] = None
+    meme_text: Optional[str] = None
     health: UserCatHealth = Field(default_factory=UserCatHealth)
     created_at: datetime
     updated_at: datetime

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,7 @@ ZIPSA FastAPI 서버 엔트리포인트
   DELETE /api/v1/users/me/cats/{id}               — 고양이 삭제
   POST /api/v1/chat/invoke                        — 동기 채팅
   POST /api/v1/chat/stream                        — SSE 스트리밍
+  POST /api/v1/meme/analyze                       — Vision AI 밈 생성
 """
 import os
 from pathlib import Path
@@ -65,6 +66,8 @@ if not os.getenv("OCI_NAMESPACE"):
 
     static_dir = Path(__file__).parents[1] / "static"
     static_dir.mkdir(exist_ok=True)
+    (static_dir / "meme").mkdir(exist_ok=True)
+    (static_dir / "cats").mkdir(exist_ok=True)
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 


### PR DESCRIPTION
## Summary

- **#36 백엔드**: GPT-4o-mini Vision API 연동 — 고양이 사진 → 시니컬한 밈 텍스트 생성
- **#35 프론트엔드**: `/meme` 페이지 — 폴라로이드 카드 렌더링, 2-column 레이아웃
- **#37 UserCat 1-Click 등록**: 밈 결과에서 내 고양이 바로 등록, meme_text/이미지 편집 지원

## Changes

**백엔드**
- `POST /api/v1/meme/analyze` — 이미지 업로드 → Vision AI → `meme_text`, `breed_guess`, `age_guess`, `age_months` 반환
- `POST /api/v1/users/me/cats/upload-image` — 고양이 프로필 이미지 업로드
- `UserCat`에 `meme_text` 필드 추가
- 이미지 로컬 저장: `static/meme/`, `static/cats/`

**프론트엔드**
- `/meme` 페이지 신규 구현 (보호 경로 추가)
- `my-cats/[id]` 수정 페이지 — 이미지 업로드 UI, `meme_text` textarea
- `UserCatCard` — `meme_text` italic 표시
- `outline` 버튼 `bg-white` 고정 (다크모드 버튼 비가시 버그 수정)

## Test plan

- [x] `/meme` 접근 시 로그인 리다이렉트 확인
- [x] 고양이 사진 업로드 → 폴라로이드 카드에 밈 텍스트/품종/나이 표시
- [x] "내 고양이로 등록" → `/my-cats`에서 확인
- [x] `my-cats/[id]` 수정 페이지에서 이미지 업로드 및 냥심 한 마디 편집