### PR TITLE
fix: LangGraph MongoDBSaver 호환성 수정 및 세션 타이틀 자동 생성

### DIFF
--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -5,9 +5,9 @@ LangGraph 워크플로우 정의 (고양이 집사 서비스)
 import os
 
 import certifi
-from pymongo import MongoClient
+from motor.motor_asyncio import AsyncIOMotorClient
 from langgraph.graph import StateGraph, START, END
-from langgraph.checkpoint.mongodb import MongoDBSaver
+from langgraph.checkpoint.mongodb.aio import AsyncMongoDBSaver
 from langgraph.prebuilt import ToolNode
 
 from .state import AgentState
@@ -21,8 +21,11 @@ from .tools.animal_protection import search_abandoned_animals
 tools = [search_abandoned_animals]
 tool_node = ToolNode(tools)
 
+# lifespan에서 초기화됨 (None 상태로 시작)
+app = None
 
-def create_zipsa_graph():
+
+async def create_zipsa_graph():
     """
     에이전트 그래프 생성:
     - head_butler: 메인 라우터 겸 유일한 종료 지점. 모든 전문가의 결과는 여기로 모임.
@@ -30,13 +33,14 @@ def create_zipsa_graph():
     - liaison: 입양/구조 정보 (RAG specialist=Liaison + 동물보호 API 도구)
     - tools: 국가동물보호정보시스템 조회 (liaison이 호출)
     - care: 건강 + 행동 상담 (Physician + Peacekeeper 통합)
-    
-    참고: 각 노드는 Command(goto=...)를 사용하여 동적 라우팅을 수행하므로, 
+
+    참고: 각 노드는 Command(goto=...)를 사용하여 동적 라우팅을 수행하므로,
     아래 정의된 static edges는 주로 그래프 시각화 및 구조 명시용으로 작동합니다.
     """
+    motor_client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    checkpointer = AsyncMongoDBSaver(motor_client)
+    await checkpointer.setup()  # checkpoint 컬렉션 인덱스 생성
 
-    mongo_client = MongoClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
-    checkpointer = MongoDBSaver(mongo_client)
     workflow = StateGraph(AgentState)
 
     # 1. 노드 등록 (Node Registration)
@@ -88,7 +92,3 @@ def create_zipsa_graph():
     workflow.add_edge("care", "head_butler")
 
     return workflow.compile(checkpointer=checkpointer)
-
-
-# 앱 인스턴스 생성 및 내보내기
-app = create_zipsa_graph()

--- a/src/agents/graph.py
+++ b/src/agents/graph.py
@@ -5,9 +5,9 @@ LangGraph 워크플로우 정의 (고양이 집사 서비스)
 import os
 
 import certifi
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import MongoClient
 from langgraph.graph import StateGraph, START, END
-from langgraph.checkpoint.mongodb.aio import AsyncMongoDBSaver
+from langgraph.checkpoint.mongodb import MongoDBSaver
 from langgraph.prebuilt import ToolNode
 
 from .state import AgentState
@@ -37,9 +37,8 @@ async def create_zipsa_graph():
     참고: 각 노드는 Command(goto=...)를 사용하여 동적 라우팅을 수행하므로,
     아래 정의된 static edges는 주로 그래프 시각화 및 구조 명시용으로 작동합니다.
     """
-    motor_client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
-    checkpointer = AsyncMongoDBSaver(motor_client)
-    await checkpointer.setup()  # checkpoint 컬렉션 인덱스 생성
+    mongo_client = MongoClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
+    checkpointer = MongoDBSaver(mongo_client)
 
     workflow = StateGraph(AgentState)
 

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -44,16 +44,26 @@ async def _get_session_or_404(session_id: str, user_id: str) -> dict:
     return doc
 
 
-async def _update_session_meta(session_id: str, last_message: str, increment: int = 2) -> None:
+async def _update_session_meta(
+    session_id: str, last_message: str, title: str | None = None, increment: int = 2
+) -> None:
     """세션의 last_message, message_count, updated_at 갱신."""
     col = _get_sessions_col()
+    set_fields: dict = {"last_message": last_message, "updated_at": datetime.now(timezone.utc)}
+    if title is not None:
+        set_fields["title"] = title
     await col.update_one(
         {"_id": ObjectId(session_id)},
         {
-            "$set": {"last_message": last_message, "updated_at": datetime.now(timezone.utc)},
+            "$set": set_fields,
             "$inc": {"message_count": increment},
         },
     )
+
+
+def _auto_title(message: str) -> str:
+    """첫 메시지에서 세션 타이틀 자동 생성 (최대 30자)."""
+    return message[:30] + ("..." if len(message) > 30 else "")
 
 
 @router.post("/invoke", response_model=ChatInvokeResponse)
@@ -87,7 +97,8 @@ async def invoke_chat(
         for r in result.get("recommendations", [])
     ]
 
-    await _update_session_meta(body.session_id, body.message)
+    title = _auto_title(body.message) if not session.get("title") else None
+    await _update_session_meta(body.session_id, body.message, title=title)
 
     message_id = f"{thread_id}-{len(result.get('messages', []))}"
     return ChatInvokeResponse(
@@ -153,7 +164,8 @@ async def stream_chat(
             yield f"data: {json.dumps({'type': 'error', 'content': '응답 생성 중 오류가 발생했습니다.'})}\n\n"
         finally:
             if full_content:
-                await _update_session_meta(body.session_id, body.message)
+                title = _auto_title(body.message) if not session.get("title") else None
+                await _update_session_meta(body.session_id, body.message, title=title)
             yield "data: [DONE]\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -16,7 +16,7 @@ from fastapi.responses import StreamingResponse
 from langchain_core.messages import HumanMessage, AIMessage
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from src.agents.graph import app as graph_app
+import src.agents.graph as graph_module
 from src.api.dependencies import get_current_user
 from src.core.config import AuthConfig
 from src.core.models.auth import AuthUser
@@ -65,7 +65,7 @@ async def invoke_chat(
     session = await _get_session_or_404(body.session_id, current_user.user_id)
     thread_id = session["thread_id"]
 
-    result = await graph_app.ainvoke(
+    result = await graph_module.app.ainvoke(
         {
             "messages": [HumanMessage(content=body.message)],
             "user_profile": {},
@@ -114,7 +114,7 @@ async def stream_chat(
         rescue_cats = []
 
         try:
-            async for event in graph_app.astream_events(
+            async for event in graph_module.app.astream_events(
                 {
                     "messages": [HumanMessage(content=body.message)],
                     "user_profile": body.user_profile or {},

--- a/src/api/routers/sessions.py
+++ b/src/api/routers/sessions.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from langchain_core.messages import AIMessage, HumanMessage
 from motor.motor_asyncio import AsyncIOMotorClient
 
+import src.agents.graph as graph_module
 from src.api.dependencies import get_current_user
 from src.core.config import AuthConfig
 from src.core.models.auth import AuthUser
@@ -31,9 +32,6 @@ def _get_sessions_col():
     return client[AuthConfig.USER_DB_NAME]["chat_sessions"]
 
 
-def _get_checkpoints_col():
-    client = AsyncIOMotorClient(os.getenv("MONGO_V3_URI"), tlsCAFile=certifi.where())
-    return client["zipsa"]["checkpoints"]
 
 
 def _doc_to_response(doc: dict) -> ChatSessionResponse:
@@ -105,9 +103,10 @@ async def delete_session(
     result = await col.delete_one({"_id": ObjectId(session_id), "user_id": current_user.user_id})
     if result.deleted_count == 0:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
-    # LangGraph 체크포인트 삭제
-    checkpoints = _get_checkpoints_col()
-    await checkpoints.delete_many({"thread_id": session_id})
+    # LangGraph 체크포인트 삭제 (checkpoints + checkpoint_writes)
+    checkpointer = graph_module.app.checkpointer
+    await checkpointer.collection.delete_many({"thread_id": session_id})
+    await checkpointer.writes.delete_many({"thread_id": session_id})
 
 
 @router.get("/{session_id}/messages", response_model=list[ChatMessageResponse])
@@ -122,8 +121,7 @@ async def list_messages(
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
 
-    from src.agents.graph import app as graph_app
-    state = await graph_app.aget_state({"configurable": {"thread_id": session_id}})
+    state = await graph_module.app.aget_state({"configurable": {"thread_id": session_id}})
     if not state or not state.values:
         return []
 

--- a/src/api/routers/sessions.py
+++ b/src/api/routers/sessions.py
@@ -103,10 +103,8 @@ async def delete_session(
     result = await col.delete_one({"_id": ObjectId(session_id), "user_id": current_user.user_id})
     if result.deleted_count == 0:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
-    # LangGraph 체크포인트 삭제 (checkpoints + checkpoint_writes)
-    checkpointer = graph_module.app.checkpointer
-    await checkpointer.collection.delete_many({"thread_id": session_id})
-    await checkpointer.writes.delete_many({"thread_id": session_id})
+    # LangGraph 체크포인트 삭제
+    await graph_module.app.checkpointer.adelete_thread(session_id)
 
 
 @router.get("/{session_id}/messages", response_model=list[ChatMessageResponse])

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ ZIPSA FastAPI 서버 엔트리포인트
   POST /api/v1/meme/analyze                       — Vision AI 밈 생성
 """
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -37,11 +38,21 @@ from fastapi.staticfiles import StaticFiles
 load_dotenv(Path(__file__).parents[1] / ".env")
 
 from src.api.routers import auth, cats, chat, meme, sessions, users
+import src.agents.graph as graph_module
+
+
+@asynccontextmanager
+async def lifespan(fastapi_app: FastAPI):
+    """서버 시작 시 LangGraph 그래프를 초기화합니다 (AsyncMongoDBSaver + setup)."""
+    graph_module.app = await graph_module.create_zipsa_graph()
+    yield
+
 
 app = FastAPI(
     title="ZIPSA API",
     version="1.0.0",
     description="AI 기반 고양이 품종 매칭 및 케어 상담 서비스",
+    lifespan=lifespan,
 )
 
 app.add_middleware(


### PR DESCRIPTION
## Summary

- **AsyncMongoDBSaver → MongoDBSaver 롤백**: `langgraph-checkpoint-mongodb==0.3.1`에서 `AsyncMongoDBSaver`가 제거됨 (`aio` 서브모듈 없음). `MongoDBSaver`가 내부적으로 async 메서드(`aget`, `aput`, `adelete_thread`)를 지원하므로 이걸로 교체
- **sessions.py 체크포인트 연동 수정**: `delete_session`에서 하드코딩된 DB 이름 제거 → `checkpointer.adelete_thread(session_id)` 사용
- **chat.py import 패턴 수정**: 모듈 레벨 `from ... import app` → `import graph_module` 참조 방식으로 변경해 `None` 캡처 방지
- **채팅 세션 자동 타이틀 생성**: 첫 메시지 전송 시 세션 타이틀을 자동으로 설정 (최대 30자 truncation). 기존 타이틀 있으면 덮어쓰지 않음

## Test plan

- [x] 새 채팅 세션 생성 후 첫 메시지 전송 → 세션 목록에서 "새 대화" 대신 메시지 내용으로 타이틀 표시 확인
- [x] 30자 초과 메시지는 "..." 말줄임 표시 확인
- [x] 세션 삭제 시 LangGraph 체크포인트도 함께 삭제되는지 확인
- [x] 서버 재시작 후 채팅 히스토리 복원 확인 (MongoDBSaver 정상 동작)

Closes #29, Closes #33