### PR TITLE
docs: API 명세서·MongoDB 스키마·Page 명세서 최신화 (closes #15, #17, #18)

### DIFF
--- a/docs/08_backend/zipsa_openapi.yaml
+++ b/docs/08_backend/zipsa_openapi.yaml
@@ -2,12 +2,12 @@ openapi: 3.0.3
 info:
   title: ZIPSA API
   description: AI 기반 고양이 품종 매칭 및 케어 상담 서비스 백엔드 API
-  version: 1.0.0
+  version: 2.0.0
 
 servers:
   - url: http://localhost:8000/api/v1
     description: 로컬 개발 서버
-  - url: https://api.zipsa.app/api/v1
+  - url: https://zipsa.leemdo.com/api/v1
     description: 프로덕션 서버
 
 security:
@@ -19,7 +19,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: NextAuth.js 발급 JWT 토큰
+      description: ZIPSA JWT 토큰 (POST /auth/sync 로 발급)
 
   schemas:
     # ── 공통 ──────────────────────────────────────────
@@ -29,6 +29,58 @@ components:
         detail:
           type: string
           example: "리소스를 찾을 수 없습니다."
+
+    # ── 인증 ──────────────────────────────────────────
+    SyncRequest:
+      type: object
+      required: [email, provider]
+      properties:
+        email:
+          type: string
+          description: OAuth 이메일
+        name:
+          type: string
+          nullable: true
+          description: 표시 이름
+        image:
+          type: string
+          nullable: true
+          description: 프로필 이미지 URL
+        provider:
+          type: string
+          description: OAuth 프로바이더
+          example: "google"
+
+    SyncResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: ZIPSA JWT 액세스 토큰
+        token_type:
+          type: string
+          example: "bearer"
+        user_id:
+          type: string
+        email:
+          type: string
+
+    MeResponse:
+      type: object
+      properties:
+        user_id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+          nullable: true
+        image:
+          type: string
+          nullable: true
+        provider:
+          type: string
+          nullable: true
 
     # ── 유저 프로필 ───────────────────────────────────
     UserPreferences:
@@ -160,15 +212,24 @@ components:
           description: "업로드 완료 후 공개 조회 URL. PUT /users/me/profile에 포함"
 
     # ── 고양이 ────────────────────────────────────────
-    Vaccination:
+    VaccinationInfo:
       type: object
       properties:
-        type:
+        label:
           type: string
           example: "종합백신 3차"
         date:
           type: string
           format: date
+          example: "2024-03-15"
+
+    UserCatHealth:
+      type: object
+      properties:
+        vaccinations:
+          type: array
+          items:
+            $ref: '#/components/schemas/VaccinationInfo'
 
     UserCatResponse:
       type: object
@@ -184,25 +245,19 @@ components:
         gender:
           type: string
           enum: [M, F, 미상]
-        breed_id:
-          type: string
-          nullable: true
-          description: "67종 중 매핑된 품종 ID. 혼합묘/기타이면 null"
         breed_name_ko:
           type: string
         breed_name_en:
           type: string
-          nullable: true
         profile_image_url:
           type: string
           nullable: true
+        meme_text:
+          type: string
+          nullable: true
+          description: "냥심 번역기에서 생성된 밈 텍스트"
         health:
-          type: object
-          properties:
-            vaccinations:
-              type: array
-              items:
-                $ref: '#/components/schemas/Vaccination'
+          $ref: '#/components/schemas/UserCatHealth'
         created_at:
           type: string
           format: date-time
@@ -212,33 +267,31 @@ components:
 
     UserCatCreateRequest:
       type: object
-      required: [name, age_months, gender, breed_name_ko]
+      required: [name]
       properties:
         name:
           type: string
         age_months:
           type: integer
+          default: 0
         gender:
           type: string
           enum: [M, F, 미상]
-        breed_id:
-          type: string
-          nullable: true
+          default: 미상
         breed_name_ko:
           type: string
+          default: ""
         breed_name_en:
           type: string
-          nullable: true
+          default: ""
         profile_image_url:
           type: string
           nullable: true
+        meme_text:
+          type: string
+          nullable: true
         health:
-          type: object
-          properties:
-            vaccinations:
-              type: array
-              items:
-                $ref: '#/components/schemas/Vaccination'
+          $ref: '#/components/schemas/UserCatHealth'
 
     UserCatUpdateRequest:
       type: object
@@ -250,24 +303,26 @@ components:
         gender:
           type: string
           enum: [M, F, 미상]
-        breed_id:
-          type: string
-          nullable: true
         breed_name_ko:
           type: string
         breed_name_en:
           type: string
-          nullable: true
         profile_image_url:
           type: string
           nullable: true
+        meme_text:
+          type: string
+          nullable: true
         health:
-          type: object
-          properties:
-            vaccinations:
-              type: array
-              items:
-                $ref: '#/components/schemas/Vaccination'
+          $ref: '#/components/schemas/UserCatHealth'
+
+    CatImageUploadResponse:
+      type: object
+      properties:
+        image_url:
+          type: string
+          description: "/static/cats/{uuid}.jpg 형식의 로컬 정적 파일 URL"
+          example: "/static/cats/550e8400-e29b-41d4-a716-446655440000.jpg"
 
     # ── 채팅 세션 ─────────────────────────────────────
     ChatSessionResponse:
@@ -281,6 +336,8 @@ components:
           type: string
         title:
           type: string
+          nullable: true
+          description: "null이면 첫 메시지 전송 시 자동 설정 (최대 30자)"
         last_message:
           type: string
           nullable: true
@@ -326,8 +383,10 @@ components:
           type: string
         name_en:
           type: string
+          nullable: true
         image_url:
           type: string
+          nullable: true
         summary:
           type: string
         tags:
@@ -336,6 +395,37 @@ components:
             type: string
         stats:
           $ref: '#/components/schemas/CatCardStats'
+
+    RescueCat:
+      type: object
+      description: "국가동물보호정보시스템 유기묘 정보"
+      properties:
+        animal_id:
+          type: string
+        breed:
+          type: string
+        age:
+          type: string
+        sex:
+          type: string
+        neutered:
+          type: string
+        feature:
+          type: string
+        image_url:
+          type: string
+        shelter_name:
+          type: string
+        shelter_address:
+          type: string
+        shelter_phone:
+          type: string
+        notice_end_date:
+          type: string
+        sido:
+          type: string
+        sigungu:
+          type: string
 
     ChatMessageResponse:
       type: object
@@ -357,6 +447,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RagDoc'
+        rescue_cats:
+          type: array
+          items:
+            $ref: '#/components/schemas/RescueCat'
         created_at:
           type: string
           format: date-time
@@ -369,6 +463,10 @@ components:
           type: string
         message:
           type: string
+        user_profile:
+          type: object
+          nullable: true
+          description: "프론트에서 전달하는 온보딩 프로파일 (선택)"
 
     ChatInvokeResponse:
       type: object
@@ -385,50 +483,83 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RagDoc'
+        rescue_cats:
+          type: array
+          items:
+            $ref: '#/components/schemas/RescueCat'
 
-    # ── 품종 ──────────────────────────────────────────
-    BreedResponse:
+    # ── 밈 ────────────────────────────────────────────
+    MemeAnalyzeResponse:
       type: object
       properties:
-        breed_id:
+        meme_text:
           type: string
-        name_ko:
+          description: "고양이 시점의 시니컬한 한 마디"
+          example: "\"난 이미 알고 있었어. 네가 오늘도 늦을 거라는 것을.\""
+        breed_guess:
           type: string
-        name_en:
+          description: "추정 품종명 (조사/문장 없이)"
+          example: "래그돌"
+        age_guess:
           type: string
-        summary:
-          type: string
+          description: "표시용 나이 문자열"
+          example: "약 2살 추정"
+        age_months:
+          type: integer
+          description: "등록용 나이(개월 수)"
+          example: 24
         image_url:
           type: string
-          nullable: true
+          description: "/static/meme/{uuid}.jpg 형식의 로컬 정적 파일 URL"
+          example: "/static/meme/550e8400-e29b-41d4-a716-446655440000.jpg"
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 paths:
 
   # ── Auth ──────────────────────────────────────────────────────────────────
-  /auth/me:
-    get:
+  /auth/sync:
+    post:
       tags: [Auth]
-      summary: 현재 로그인 유저 정보 조회
-      description: JWT 토큰에서 user_id, email을 추출하여 반환합니다.
+      summary: NextAuth 세션 동기화 및 JWT 발급
+      description: |
+        NextAuth 로그인 완료 후 호출합니다.
+        users 컬렉션에 upsert하고 ZIPSA JWT를 반환합니다.
+        이후 모든 API 요청에 Authorization: Bearer {access_token} 헤더를 포함합니다.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncRequest'
       responses:
         '200':
           description: 성공
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_id:
-                    type: string
-                  email:
-                    type: string
-                  name:
-                    type: string
-                  image:
-                    type: string
+                $ref: '#/components/schemas/SyncResponse'
+
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: 현재 로그인 유저 정보 조회
+      description: JWT 토큰에서 user_id를 추출해 MongoDB에서 유저 정보를 반환합니다.
+      responses:
+        '200':
+          description: 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeResponse'
         '401':
           description: 인증 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 유저 없음
           content:
             application/json:
               schema:
@@ -492,11 +623,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserProfileResponse'
+        '404':
+          description: 프로필 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /users/me/profile/avatar/presign:
     post:
       tags: [User Profile]
-      summary: 아바타 업로드 PAR URL 발급
+      summary: 아바타 업로드 PAR URL 발급 (OCI)
       description: |
         OCI Object Storage Pre-Authenticated Request URL을 발급합니다.
         클라이언트는 반환된 upload_url로 PUT 요청을 보내 이미지를 직접 업로드합니다.
@@ -541,6 +678,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserCatResponse'
 
+  /users/me/cats/upload-image:
+    post:
+      tags: [User Cats]
+      summary: 고양이 프로필 이미지 업로드
+      description: |
+        multipart/form-data로 이미지를 업로드합니다.
+        반환된 image_url을 UserCatCreateRequest/UpdateRequest의 profile_image_url에 사용합니다.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: 업로드 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatImageUploadResponse'
+
   /users/me/cats/{cat_id}:
     parameters:
       - name: cat_id
@@ -582,6 +745,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserCatResponse'
+        '404':
+          description: 고양이 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
     delete:
       tags: [User Cats]
@@ -589,6 +758,12 @@ paths:
       responses:
         '204':
           description: 삭제 성공
+        '404':
+          description: 고양이 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   # ── Chat Sessions ─────────────────────────────────────────────────────────
   /users/me/sessions:
@@ -601,6 +776,8 @@ paths:
           schema:
             type: integer
             default: 20
+            minimum: 1
+            maximum: 100
         - name: offset
           in: query
           schema:
@@ -608,7 +785,7 @@ paths:
             default: 0
       responses:
         '200':
-          description: 성공
+          description: 성공 (updated_at 내림차순)
           content:
             application/json:
               schema:
@@ -661,10 +838,16 @@ paths:
     delete:
       tags: [Chat Sessions]
       summary: 세션 삭제
-      description: 세션 및 연결된 메시지, LangGraph 체크포인트를 함께 삭제합니다.
+      description: 세션 및 연결된 LangGraph 체크포인트를 함께 삭제합니다.
       responses:
         '204':
           description: 삭제 성공
+        '404':
+          description: 세션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   # ── Chat Messages ─────────────────────────────────────────────────────────
   /users/me/sessions/{session_id}/messages:
@@ -678,17 +861,15 @@ paths:
     get:
       tags: [Chat Messages]
       summary: 세션 메시지 목록 조회
+      description: LangGraph MongoDBSaver 체크포인트에서 메시지를 복원합니다.
       parameters:
         - name: limit
           in: query
           schema:
             type: integer
             default: 50
-        - name: before
-          in: query
-          schema:
-            type: string
-          description: "커서 기반 페이지네이션: 이 message_id 이전 메시지 조회"
+            minimum: 1
+            maximum: 200
       responses:
         '200':
           description: 성공
@@ -698,6 +879,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ChatMessageResponse'
+        '404':
+          description: 세션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   # ── Chat (Agent) ──────────────────────────────────────────────────────────
   /chat/invoke:
@@ -717,14 +904,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChatInvokeResponse'
+        '500':
+          description: 에이전트 응답 생성 실패
 
   /chat/stream:
     post:
       tags: [Chat]
-      summary: 메시지 전송 (스트리밍 응답)
+      summary: 메시지 전송 (SSE 스트리밍 응답)
       description: |
         Server-Sent Events(SSE)로 LangGraph 에이전트 응답을 스트리밍합니다.
-        LangServe `astream_events v2` 기반.
+        `astream_events v2` 기반. `router_classification` 태그 내부 호출은 필터링됩니다.
       requestBody:
         required: true
         content:
@@ -742,28 +931,46 @@ paths:
                   이벤트 형식:
                   - `data: {"type": "token", "content": "..."}` — 텍스트 토큰
                   - `data: {"type": "recommendations", "data": [...]}` — 품종 카드
-                  - `data: {"type": "rag_docs", "data": [...]}` — 출처
+                  - `data: {"type": "rag_docs", "data": [...]}` — 출처 문서
+                  - `data: {"type": "rescue_cats", "data": [...]}` — 유기묘 정보
+                  - `data: {"type": "error", "content": "..."}` — 오류
                   - `data: [DONE]` — 스트림 종료
 
-  # ── Breeds ────────────────────────────────────────────────────────────────
-  /breeds:
-    get:
-      tags: [Breeds]
-      summary: 품종 목록 조회 (67종)
-      description: 드랍다운 및 Interactive Text 자동완성용 품종 리스트
-      security: []
-      parameters:
-        - name: q
-          in: query
-          schema:
-            type: string
-          description: "name_ko 검색 (자동완성용)"
+  # ── Meme ──────────────────────────────────────────────────────────────────
+  /meme/analyze:
+    post:
+      tags: [Meme]
+      summary: 냥심 번역기 — 고양이 사진 분석
+      description: |
+        고양이 사진을 업로드하면 GPT-4o-mini Vision이 분석하여
+        시니컬한 밈 텍스트, 추정 품종, 추정 나이를 반환합니다.
+        반환된 image_url과 breed_guess, age_months를 이용해 내 고양이로 바로 등록할 수 있습니다.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                  format: binary
+                  description: 고양이 사진 (jpg/png 등)
+                context:
+                  type: string
+                  default: ""
+                  description: "추가 컨텍스트 (선택). 예: '우리 집 고양이인데 항상 이런 표정이에요'"
       responses:
         '200':
-          description: 성공
+          description: 분석 성공
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BreedResponse'
+                $ref: '#/components/schemas/MemeAnalyzeResponse'
+        '502':
+          description: Vision API 호출 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'


### PR DESCRIPTION
## Summary

3개 문서를 실제 구현 기준으로 전면 업데이트합니다.

---

### `zipsa_openapi.yaml` (closes #17)

**추가**
- `POST /auth/sync` — NextAuth 동기화 & JWT 발급
- `POST /meme/analyze` — 냥심 번역기 Vision AI
- `POST /users/me/cats/upload-image` — 고양이 이미지 업로드
- 스키마: `SyncRequest/Response`, `MemeAnalyzeResponse`, `RescueCat`, `CatImageUploadResponse`

**수정**
- `UserCat*`: `breed_id` 제거, `meme_text` 추가
- `VaccinationInfo.type` → `label`
- `ChatMessage/InvokeResponse`: `rescue_cats` 추가
- `ChatInvokeRequest`: `user_profile` 옵션 추가
- 서버 URL: `api.zipsa.app` → `zipsa.leemdo.com`

**제거**: `GET /breeds` (미구현), 메시지 `before` 커서 파라미터 (미구현)

---

### `mongodb_user_schema.md` (closes #15)

- DB명: `zipsa_app` → `zipsa` (`MONGO_V3_URI` 단일 사용)
- 인증: NextAuth MongoDB Adapter 미사용 명시 (`/auth/sync` 커스텀 방식)
- `users` 컬렉션: 백엔드 직접 관리 (provider, created_at/updated_at 등)
- NextAuth 전용 컬렉션(`accounts`, `sessions` 등) 제거
- `chat_messages` 컬렉션 제거 (메시지는 LangGraph `checkpoints`에 저장)
- `checkpoints` → `checkpoints` + `checkpoint_writes` 두 컬렉션
- `user_cats`: `meme_text` 추가, `vaccinations.type` → `label`

---

### `app_router_spec.md` (closes #18)

- 경로 수정: `/auth/signin` → `/login`, `/profile/cats` → `/my-cats`
- `/meme` (냥심 번역기) 추가
- 접근 제어: 실제 `middleware.ts` 보호 경로 기준
- 상태 관리: Zustand (`useSessionStore`, `useChatStore`) 반영
- `/breeds` 미구현 섹션 제거

---

## Test plan

- [ ] Swagger Editor에서 `zipsa_openapi.yaml` 로드 → 파싱 오류 없음 확인
- [ ] 실제 FastAPI `/docs`와 스키마 일치 확인
- [ ] 문서 링크 및 관련 이슈 참조 일치 확인

Closes #15, Closes #17, Closes #18