### PR TITLE
feat: 랜딩 페이지 전면 개편

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,8 +5,11 @@ import { Navigation } from "@/components/layout/Navigation";
 import { GlobalDrawer } from "@/components/layout/GlobalDrawer";
 import { Hero } from "@/components/landing/Hero";
 import { HowItWorks } from "@/components/landing/HowItWorks";
+import { DemoSection } from "@/components/landing/DemoSection";
 import { Features } from "@/components/landing/Features";
+import { MemePreview } from "@/components/landing/MemePreview";
 import { FinalCTA } from "@/components/landing/FinalCTA";
+import { FloatingButtons } from "@/components/landing/FloatingButtons";
 
 export default function HomePage() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -16,9 +19,12 @@ export default function HomePage() {
       <Navigation onMenuClick={() => setDrawerOpen(true)} />
       <GlobalDrawer isOpen={drawerOpen} onClose={() => setDrawerOpen(false)} />
       <Hero />
-      <HowItWorks />
+      <DemoSection />
       <Features />
+      <HowItWorks />
+      <MemePreview />
       <FinalCTA />
+      <FloatingButtons />
     </div>
   );
 }

--- a/frontend/src/components/landing/DemoSection.tsx
+++ b/frontend/src/components/landing/DemoSection.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { CatCard } from "@/components/chat/CatCard";
+import { RescueCatCard } from "@/components/chat/RescueCatCard";
+import type { Recommendation, RescueCat } from "@/lib/api";
+
+// ── 시나리오별 목업 데이터 ────────────────────────────────────────────────────
+
+const breedScenario: {
+  messages: { role: "human" | "ai"; content: string }[];
+  breed: Recommendation;
+} = {
+  messages: [
+    {
+      role: "human",
+      content: "1인 가구인데 조용하고 순한 고양이를 찾고 있어요. 혼자 있는 시간이 많아요.",
+    },
+    {
+      role: "ai",
+      content:
+        "집사님의 환경에 딱 맞는 래그돌을 추천드릴게요! 인형처럼 온순하고, 혼자 있는 시간도 잘 견디며 조용한 성격이라 1인 가구에 최적입니다.",
+    },
+  ],
+  breed: {
+    name_ko: "래그돌",
+    name_en: "Ragdoll",
+    image_url: "",
+    summary:
+      "인형처럼 축 늘어지는 대형묘로 극도로 온순합니다. 조용하고 순종적이며, 혼자 있는 시간도 잘 견뎌 1인 가구에 잘 어울립니다.",
+    tags: ["온순함", "조용함", "친화적", "실내 적합"],
+    stats: {},
+  },
+};
+
+const rescueScenario: {
+  messages: { role: "human" | "ai"; content: string }[];
+  cat: RescueCat;
+} = {
+  messages: [
+    {
+      role: "human",
+      content: "직접 입양하고 싶은데, 지금 보호 중인 고양이가 있나요?",
+    },
+    {
+      role: "ai",
+      content:
+        "국가동물보호정보시스템에서 입양 가능한 아이를 찾아왔어요! 온순하고 건강상태도 양호해요.",
+    },
+  ],
+  cat: {
+    animal_id: "DEMO001",
+    breed: "코리안숏헤어",
+    age: "2살 추정",
+    sex: "여",
+    neutered: "중성화 완료",
+    feature: "온순하고 사람을 잘 따릅니다. 건강상태 양호, 기본 접종 완료.",
+    image_url: "",
+    shelter_name: "서울특별시 동물보호센터",
+    shelter_address: "서울시 마포구 상암동",
+    shelter_phone: "02-000-0000",
+    notice_end_date: "2026-03-31",
+    sido: "서울",
+    sigungu: "마포구",
+  },
+};
+
+// ── 컴포넌트 ─────────────────────────────────────────────────────────────────
+
+export function DemoSection() {
+  const [tab, setTab] = useState<"breed" | "rescue">("breed");
+
+  const scenario = tab === "breed" ? breedScenario : rescueScenario;
+
+  return (
+    <section className="w-full border-b border-gray-300 bg-gray-100">
+      <div className="max-w-[1440px] mx-auto px-16 py-20">
+        <h2 className="text-3xl font-bold text-center mb-4 text-gray-900">
+          이렇게 대화해요
+        </h2>
+        <p className="text-center text-gray-500 mb-12">
+          AI 집사와 나눈 대화 한 마디로, 맞춤 품종 추천부터 입양 정보까지 바로 확인할 수 있어요.
+        </p>
+
+        {/* 시나리오 탭 */}
+        <div className="flex justify-center mb-8">
+          <div className="inline-flex border-2 border-gray-300 rounded-lg overflow-hidden">
+            <button
+              onClick={() => setTab("breed")}
+              className={`px-6 py-2.5 text-sm font-medium transition-colors ${
+                tab === "breed"
+                  ? "bg-gray-900 text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              품종 추천
+            </button>
+            <button
+              onClick={() => setTab("rescue")}
+              className={`px-6 py-2.5 text-sm font-medium transition-colors border-l-2 border-gray-300 ${
+                tab === "rescue"
+                  ? "bg-gray-900 text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              구조묘 입양
+            </button>
+          </div>
+        </div>
+
+        {/* 채팅 UI 미리보기 */}
+        <div className="border-2 border-gray-300 rounded-xl overflow-hidden flex h-[520px] shadow-sm">
+
+          {/* 좌측: 채팅 영역 */}
+          <div className="flex-1 flex flex-col border-r-2 border-gray-300">
+            {/* 헤더 */}
+            <div className="h-14 px-5 border-b-2 border-gray-300 flex items-center gap-3 bg-white flex-shrink-0">
+              <div className="w-7 h-7 rounded-full bg-gray-900 flex items-center justify-center">
+                <span className="text-white text-xs font-bold">Z</span>
+              </div>
+              <span className="text-sm font-bold text-gray-900">ZIPSA 집사</span>
+            </div>
+
+            {/* 메시지 */}
+            <div className="flex-1 p-5 space-y-4 overflow-y-auto bg-gray-100">
+              {scenario.messages.map((msg, i) =>
+                msg.role === "human" ? (
+                  <div key={i} className="flex justify-end">
+                    <div className="bg-gray-200 border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-sm">
+                      <p className="text-gray-900 text-sm leading-relaxed">{msg.content}</p>
+                    </div>
+                  </div>
+                ) : (
+                  <div key={i} className="flex justify-start gap-3">
+                    <div className="w-7 h-7 rounded-full bg-gray-900 flex items-center justify-center flex-shrink-0 mt-1">
+                      <span className="text-white text-xs font-bold">Z</span>
+                    </div>
+                    <div className="bg-white border-2 border-gray-300 rounded-2xl px-4 py-3 max-w-sm">
+                      <p className="text-gray-900 text-sm leading-relaxed">{msg.content}</p>
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+
+            {/* 입력창 (비활성) */}
+            <div className="border-t-2 border-gray-300 p-4 bg-white flex-shrink-0">
+              <div className="flex gap-2">
+                <div className="flex-1 h-10 border-2 border-gray-200 rounded-lg px-4 flex items-center">
+                  <span className="text-gray-400 text-sm">메시지를 입력하세요...</span>
+                </div>
+                <Link href="/chat">
+                  <Button className="h-10 bg-gray-900 text-white hover:bg-gray-800 px-4">
+                    시작하기
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          {/* 우측: 카드 패널 */}
+          <div className="w-[340px] flex flex-col bg-gray-100 flex-shrink-0">
+            <div className="h-14 px-5 border-b-2 border-gray-300 flex items-center bg-white flex-shrink-0">
+              <span className="text-sm font-bold text-gray-900">
+                {tab === "breed" ? "추천 품종" : "구조묘 정보"}
+              </span>
+            </div>
+            <div className="flex-1 p-4 overflow-y-auto">
+              {tab === "breed" ? (
+                <CatCard breed={breedScenario.breed} />
+              ) : (
+                <RescueCatCard cat={rescueScenario.cat} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="text-center mt-10">
+          <Link href="/chat">
+            <Button
+              size="lg"
+              className="bg-gray-900 hover:bg-gray-800 text-white px-10 py-6 text-base"
+            >
+              나와 맞는 고양이 찾아보기
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/Features.tsx
+++ b/frontend/src/components/landing/Features.tsx
@@ -1,48 +1,61 @@
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-
-const features = [
+const journeys = [
   {
-    emoji: "🧩",
-    title: "맞춤형 품종 매칭",
-    description: "주거환경·알레르기·활동량 기반. 67종 중 나에게 맞는 묘종 추천.",
+    tag: "준비",
+    expert: "수석 집사",
+    title: "집사님의 일상을 들려주세요",
+    quote:
+      "\"반가워요, 예비 집사님! 어떤 곳에서 누구와 함께 사시나요? 집사님의 소중한 생활 패턴을 알려주시면, 수석 집사가 가장 편안한 반려 생활을 설계해 드릴게요.\"",
+    description: "주거 환경, 활동량, 동거인 및 알레르기 유무 확인",
   },
   {
-    emoji: "🔭",
-    title: "입양 & 구조 연계",
-    description: "국가동물보호정보시스템 실시간 조회. 입양 절차·서류·비용 안내.",
+    tag: "인연",
+    expert: "매치메이커",
+    title: "운명의 묘연을 찾아드릴게요",
+    quote:
+      "\"세상에 나쁜 고양이는 없지만, 집사님과 찰떡궁합인 아이는 있답니다! 67종의 세밀한 데이터를 분석해 집사님의 성향과 딱 맞는 '묘연'을 콕 집어 추천해 드린다냥!\"",
+    description: "맞춤형 품종 매칭 및 성격 적합도 분석",
   },
   {
-    emoji: "⚖️",
-    title: "합사 & 행동 상담",
-    description: "다중묘 합사 가이드. 공격성·분리불안 등 행동학적 솔루션 제공.",
+    tag: "만남",
+    expert: "라이에종",
+    title: "설레는 첫 만남을 함께해요",
+    quote:
+      "\"마음에 쏙 드는 아이를 찾으셨나요? 가족을 맞이하는 길은 복잡하지 않아야 해요. 실시간 보호 정보 조회부터 까다로운 입양 서류 안내까지, 라이에종이 곁에서 꼼꼼히 챙겨줄게요!\"",
+    description: "국가동물보호정보시스템 연계, 입양 절차 및 비용 가이드",
   },
   {
-    emoji: "🩺",
-    title: "생애주기 건강 케어",
-    description: "증상별 초기 대응 가이드(Triage). 연령·묘종별 영양 관리 조언.",
+    tag: "동행",
+    expert: "케어팀",
+    title: "365일 든든한 지원군이 될게요",
+    quote:
+      "\"이제 진짜 시작이에요! 합사 문제로 고민될 때나 아이 건강이 걱정될 때 언제든 불러주세요. 행동 전문가와 건강 주치의가 집사님의 든든한 백업 팀이 되어 우리 아이의 평생 행복을 지켜줄게요.\"",
+    description: "다중묘 합사 가이드, 행동학적 솔루션, 생애주기별 건강 관리",
   },
 ];
 
 export function Features() {
   return (
-    <section className="w-full border-b border-gray-300 bg-gray-50">
+    <section className="w-full border-b border-gray-300 bg-white">
       <div className="max-w-[1440px] mx-auto px-16 py-20">
-        <h2 className="text-3xl font-bold text-center mb-16 text-gray-900">ZIPSA가 도와드리는 것들</h2>
+        <h2 className="text-3xl font-bold text-center mb-4 text-gray-900">
+          함께라서 더 행복한 집사 일지
+        </h2>
+        <p className="text-center text-gray-500 mb-16">
+          수석 집사부터 케어팀까지, AI 전문가 팀이 반려 생활의 모든 순간을 함께합니다.
+        </p>
         <div className="grid grid-cols-2 gap-8">
-          {features.map((feature, index) => (
-            <Card key={index} className="border-2 border-gray-300 bg-white">
-              <CardHeader>
-                <div className="flex items-center gap-3 mb-2">
-                  <span className="text-4xl">{feature.emoji}</span>
-                  <CardTitle className="text-xl text-gray-900">{feature.title}</CardTitle>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="text-gray-600 leading-relaxed">
-                  {feature.description}
-                </CardDescription>
-              </CardContent>
-            </Card>
+          {journeys.map((item, index) => (
+            <div key={index} className="border-2 border-gray-200 rounded-xl p-6 bg-gray-50 space-y-3">
+              <div className="flex items-center gap-3">
+                <span className="border border-gray-400 rounded-full px-3 py-0.5 text-xs font-semibold text-gray-600 bg-white">
+                  {item.tag}
+                </span>
+                <span className="text-sm font-medium text-gray-500">{item.expert}</span>
+              </div>
+              <h3 className="text-lg font-bold text-gray-900">{item.title}</h3>
+              <p className="text-gray-600 text-sm leading-relaxed italic">{item.quote}</p>
+              <p className="text-xs text-gray-400 pt-1">{item.description}</p>
+            </div>
           ))}
         </div>
       </div>

--- a/frontend/src/components/landing/FinalCTA.tsx
+++ b/frontend/src/components/landing/FinalCTA.tsx
@@ -1,25 +1,14 @@
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-
 export function FinalCTA() {
   return (
     <section className="w-full bg-gray-900">
       <div className="max-w-[1440px] mx-auto px-16 py-24">
         <div className="text-center space-y-6">
           <h2 className="text-4xl font-bold text-white leading-tight">
-            서로에게 맞는 만남이<br />평생 함께할 수 있습니다.
+            만남부터 이별까지,<br />집사 여러분의 행복한 여정을 기원하며.
           </h2>
           <p className="text-gray-300 text-lg">
-            ZIPSA가 당신과 고양이, 모두를 위한 최선의 매칭을 찾아드릴게요.
+            ZIPSA가 당신과 고양이, 모두를 위한 최고의 길을 찾아드릴게요.
           </p>
-          <Link href="/chat">
-            <Button
-              size="lg"
-              className="bg-white hover:bg-gray-100 text-gray-900 px-12 py-6 text-lg mt-4"
-            >
-              지금 시작하기
-            </Button>
-          </Link>
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/FloatingButtons.tsx
+++ b/frontend/src/components/landing/FloatingButtons.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowUp } from "lucide-react";
+
+export function FloatingButtons() {
+  const [showTop, setShowTop] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShowTop(window.scrollY > 300);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div className="fixed bottom-8 right-8 flex flex-col gap-3 z-50">
+      <Link
+        href="/meme"
+        className="w-14 h-14 rounded-full bg-amber-400 hover:bg-amber-500 text-gray-900 flex flex-col items-center justify-center transition-colors gap-0.5"
+        style={{ boxShadow: "0 8px 24px rgba(251,191,36,0.5)" }}
+        title="냥심 번역기"
+      >
+        <span className="text-lg leading-none">🐱</span>
+        <span className="text-[9px] font-bold leading-none">냥심번역기</span>
+      </Link>
+
+      {showTop && (
+        <button
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          className="w-14 h-14 rounded-full bg-white hover:bg-gray-50 text-gray-900 flex items-center justify-center transition-colors border border-gray-200"
+          style={{ boxShadow: "0 8px 24px rgba(0,0,0,0.15)" }}
+          title="맨 위로"
+        >
+          <ArrowUp className="w-5 h-5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -8,24 +8,24 @@ export function Hero() {
         <div className="grid grid-cols-2 gap-16 items-center">
           <div className="space-y-6">
             <div className="inline-block border-2 border-gray-300 rounded-full px-4 py-1 bg-gray-50">
-              <span className="text-sm font-medium text-gray-700">AI 수석 집사 서비스</span>
+              <span className="text-sm font-medium text-gray-700">AI 파트너 서비스</span>
             </div>
             <h1 className="text-5xl font-bold text-gray-900 leading-tight">
-              모든 집사에게는<br />수석 집사가 필요합니다.
+              완벽한 집사가 되는 길,<br />당신 곁에는 가장 스마트한<br />AI 파트너가 있습니다.
             </h1>
             <p className="text-xl text-gray-600 leading-relaxed">
-              라이프스타일 분석부터 입양, 건강 케어까지<br />
-              AI 전문가 팀이 전방위로 지원합니다.
+              라이프스타일 분석으로 찾는 최적의 입양부터 정밀 건강 케어까지,<br />
+              AI 전문가 팀의 데이터가 당신의 반려 생활을 지원합니다.
             </p>
             <div className="flex gap-4 pt-2">
               <div className="border-2 border-gray-300 rounded-lg px-4 py-2 bg-white">
-                <p className="text-sm font-bold text-gray-900">67종 품종 데이터</p>
+                <p className="text-sm font-bold text-gray-900">67종 품종 추천</p>
               </div>
               <div className="border-2 border-gray-300 rounded-lg px-4 py-2 bg-white">
-                <p className="text-sm font-bold text-gray-900">4인 전문가 AI팀</p>
+                <p className="text-sm font-bold text-gray-900">4인 AI 전문가</p>
               </div>
               <div className="border-2 border-gray-300 rounded-lg px-4 py-2 bg-white">
-                <p className="text-sm font-bold text-gray-900">파양률 감소</p>
+                <p className="text-sm font-bold text-gray-900">행복한 첫 만남</p>
               </div>
             </div>
             <Link href="/chat">
@@ -33,7 +33,7 @@ export function Hero() {
                 size="lg"
                 className="bg-gray-900 hover:bg-gray-800 text-white px-8 py-6 text-lg mt-4"
               >
-                집사 테스트 시작하기
+                행복한 만남의 첫걸음
               </Button>
             </Link>
           </div>

--- a/frontend/src/components/landing/HowItWorks.tsx
+++ b/frontend/src/components/landing/HowItWorks.tsx
@@ -4,28 +4,30 @@ const steps = [
   {
     number: 1,
     icon: Home,
-    title: "집사 환경 입력",
-    description: "주거형태, 활동량, 동거인 등 설문",
+    title: "집사님의 일상을 들려주세요",
+    description: "함께 사는 가족, 집 안 환경, 활동량 등 집사님의 생활 패턴을 알려주세요.",
   },
   {
     number: 2,
     icon: BrainCircuit,
-    title: "AI 수석 집사 분석",
-    description: "Head Butler가 의도를 파악하고 전문가 호출",
+    title: "데이터로 최적의 솔루션을 찾아요",
+    description: "Head Butler가 집사님의 마음을 읽고, AI 전문가 팀을 구성합니다.",
   },
   {
     number: 3,
     icon: CheckCircle,
-    title: "맞춤 전문가 응답",
-    description: "Matchmaker / Liaison / Care Team이 답변",
+    title: "전문가의 맞춤 처방이 시작됩니다",
+    description: "Matchmaker / Liaison / Care Team이 집사님께 딱 맞는 답변을 드립니다.",
   },
 ];
 
 export function HowItWorks() {
   return (
-    <section className="w-full border-b border-gray-300 bg-gray-50">
+    <section className="w-full border-b border-gray-300 bg-gray-100">
       <div className="max-w-[1440px] mx-auto px-16 py-20">
-        <h2 className="text-3xl font-bold text-center mb-16 text-gray-900">어떻게 작동하나요?</h2>
+        <h2 className="text-3xl font-bold text-center mb-16 text-gray-900">
+          우리 아이를 위한 맞춤 케어, 이렇게 진행돼요
+        </h2>
         <div className="grid grid-cols-3 gap-12">
           {steps.map((step) => {
             const Icon = step.icon;

--- a/frontend/src/components/landing/MemePreview.tsx
+++ b/frontend/src/components/landing/MemePreview.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function MemePreview() {
+  return (
+    <section className="w-full border-b border-gray-300 bg-white">
+      <div className="max-w-[1440px] mx-auto px-16 py-20">
+        <h2 className="text-3xl font-bold text-center mb-4 text-gray-900">
+          냥심 번역기
+        </h2>
+        <p className="text-center text-gray-500 mb-16">
+          고양이 사진을 올리면 AI가 고양이의 속마음을 대신 전해드립니다
+        </p>
+
+        <div className="grid grid-cols-2 gap-16 items-center max-w-[1000px] mx-auto">
+          {/* Left — 업로드 영역 (정적) */}
+          <div className="flex flex-col items-center">
+            <div className="w-full aspect-square border-4 border-dashed border-gray-400 bg-white rounded-lg flex flex-col items-center justify-center select-none">
+              <Upload className="w-12 h-12 text-gray-400 mb-4" strokeWidth={2} />
+              <p className="text-gray-600 text-center px-8 leading-relaxed">
+                고양이 사진을 드래그하거나<br />클릭해서 올려주세요
+              </p>
+            </div>
+
+            <div className="w-full mt-6 border-2 border-gray-300 rounded-lg px-4 py-3 bg-white text-gray-400 text-sm select-none">
+              한 마디 덧붙여 주세요 (선택사항, 예: 오늘 밥을 거부했어요)
+            </div>
+
+            <Link href="/meme" className="w-full mt-4">
+              <Button className="w-full bg-gray-900 text-white hover:bg-gray-800 rounded-lg py-6 text-base font-medium">
+                분석 시작하기
+              </Button>
+            </Link>
+          </div>
+
+          {/* Right — 폴라로이드 결과 (정적 목업) */}
+          <div className="flex flex-col items-center">
+            <div
+              className="bg-white p-6 shadow-xl"
+              style={{ transform: "rotate(2deg)", borderRadius: "4px" }}
+            >
+              <div className="w-[280px] h-[280px] bg-gray-100 border-2 border-gray-200 flex items-center justify-center">
+                <div className="text-center">
+                  <div className="text-7xl mb-2">🐱</div>
+                  <p className="text-gray-400 font-mono text-xs">CAT PHOTO</p>
+                </div>
+              </div>
+
+              <div className="mt-5 px-2 space-y-3">
+                <p className="text-gray-800 italic text-center leading-relaxed text-sm">
+                  "인간아, 지금 당장 간식을<br />내놓지 않으면 후회할 거다냥"
+                </p>
+                <div className="flex justify-center gap-2">
+                  <span className="text-xs text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
+                    코리안숏헤어
+                  </span>
+                  <span className="text-xs text-gray-500 bg-gray-100 px-3 py-1 rounded-full">
+                    약 3살 추정
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-3 mt-10">
+              <Link href="/meme">
+                <Button className="bg-gray-900 text-white hover:bg-gray-800 px-6">
+                  내 고양이로 등록
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Hero 섹션 카피 및 통계 업데이트 (AI 파트너 서비스 컨셉)
- Features 섹션을 집사 일지 Journey 카드 4단계 (준비/인연/만남/동행)로 개편
- HowItWorks 섹션 카피 업데이트
- FinalCTA 슬로건 업데이트, 버튼 제거
- DemoSection 추가: 실제 CatCard/RescueCatCard 컴포넌트를 활용한 채팅 데모 UI
- MemePreview 추가: 냥심 번역기 정적 목업 (폴라로이드 카드)
- FloatingButtons 추가: 냥심 번역기 FAB (amber) + 스크롤 탑 버튼 (흰 배경, 검정 화살표)
- 섹션 순서: Hero → DemoSection → Features → HowItWorks → MemePreview → FinalCTA
- 짝수 섹션 bg-gray-100, 홀수 섹션 bg-white 교대 배경

## Test plan

- [x] 랜딩 페이지 각 섹션 렌더링 확인
- [x] DemoSection 탭 전환 (품종 추천 / 구조묘 입양) 동작 확인
- [x] FloatingButtons 스크롤 시 탑 버튼 표시/숨김 확인
- [x] 냥심 번역기 FAB → /meme 링크 확인
- [x] 각 CTA 버튼 → /chat, /meme 링크 확인

Ref #75 